### PR TITLE
hide-hardware-info: re-enable restrictions on sysfs when using SELinux

### DIFF
--- a/usr/libexec/security-misc/hide-hardware-info
+++ b/usr/libexec/security-misc/hide-hardware-info
@@ -88,6 +88,16 @@ done
 ## properly
 if [ -d /sys/fs/selinux ]; then
     if [ "${selinux}" = "1" ]; then
+        ## restrict permissions on everything but
+        ## what is needed
+        for i in /sys/* /sys/fs/*
+        do
+          if [ "${sysfs_whitelist}" = "1" ]; then
+            chmod o-rwx "${i}"
+          else
+            chmod og-rwx "${i}"
+          fi
+        done
         chmod o+rx /sys /sys/fs /sys/fs/selinux
         echo "INFO: SELinux mode enabled. Restrictions loosened slightly in order to allow userspace utilities to function."
     else

--- a/usr/libexec/security-misc/hide-hardware-info
+++ b/usr/libexec/security-misc/hide-hardware-info
@@ -87,20 +87,20 @@ done
 ## SELinux userspace utilities will not function
 ## properly
 if [ -d /sys/fs/selinux ]; then
-    if [ "${selinux}" = "1" ]; then
-        ## restrict permissions on everything but
-        ## what is needed
-        for i in /sys/* /sys/fs/*
-        do
-          if [ "${sysfs_whitelist}" = "1" ]; then
-            chmod o-rwx "${i}"
-          else
-            chmod og-rwx "${i}"
-          fi
-        done
-        chmod o+rx /sys /sys/fs /sys/fs/selinux
-        echo "INFO: SELinux mode enabled. Restrictions loosened slightly in order to allow userspace utilities to function."
-    else
-        echo "INFO: SELinux detected, but SELinux mode is not enabled. Some userspace utilities may not work properly."
-    fi
+  if [ "${selinux}" = "1" ]; then
+    ## restrict permissions on everything but
+    ## what is needed
+    for i in /sys/* /sys/fs/*
+    do
+      if [ "${sysfs_whitelist}" = "1" ]; then
+        chmod o-rwx "${i}"
+      else
+        chmod og-rwx "${i}"
+      fi
+    done
+    chmod o+rx /sys /sys/fs /sys/fs/selinux
+    echo "INFO: SELinux mode enabled. Restrictions loosened slightly in order to allow userspace utilities to function."
+  else
+    echo "INFO: SELinux detected, but SELinux mode is not enabled. Some userspace utilities may not work properly."
+  fi
 fi

--- a/usr/libexec/security-misc/hide-hardware-info
+++ b/usr/libexec/security-misc/hide-hardware-info
@@ -9,7 +9,7 @@ sysfs_whitelist=1
 cpuinfo_whitelist=1
 
 ## https://www.whonix.org/wiki/Security-misc#selinux
-selinux=1
+selinux=0
 
 shopt -s nullglob
 


### PR DESCRIPTION
An oversight on my part simply re-enabled permissions to sysfs when SELinux was in effect. This PR fixes this by explicitly setting permissions on the contents of `/sys/*` and `/sys/fs*` instead of just `/sys` if SELinux is in use.

Additionally, fix the indentation so it's consistent with the rest of the script's style.