### PR TITLE
Continue for loop if unable to change one directory's permission

### DIFF
--- a/usr/libexec/security-misc/hide-hardware-info
+++ b/usr/libexec/security-misc/hide-hardware-info
@@ -93,9 +93,9 @@ if [ -d /sys/fs/selinux ]; then
     for i in /sys/* /sys/fs/*
     do
       if [ "${sysfs_whitelist}" = "1" ]; then
-        chmod o-rwx "${i}"
+        chmod o-rwx "${i}" || continue
       else
-        chmod og-rwx "${i}"
+        chmod og-rwx "${i}" || continue
       fi
     done
     chmod o+rx /sys /sys/fs /sys/fs/selinux


### PR DESCRIPTION
I ran the script hide-hardware-info as root and I got the message "chmod: changing permissions of '/sys/fs/resctrl': operation not permitted" 