### PR TITLE
Blacklist more kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ of multiple vulnerabilities so it is blacklisted.
 * The MSR kernel module is blacklisted to prevent CPU MSRs from being
 abused to write to arbitrary memory.
 
+* Disables a large array of uncommon file systems and network file systems that reduces the attack surface especially against legacy approaches.
+
+* Disables the use of CD-ROM devices by default.
+
+* Provides some blocking of the interface between the [Intel Management Engine (ME)](https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html) and the OS.
 ### Other
 
 * A systemd service clears the System.map file on boot as these contain kernel

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -8,25 +8,25 @@ options nf_conntrack nf_conntrack_helper=0
 # Bluetooth also has a history of security vulnerabilities:
 #
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
-install bluetooth /bin/true
-install btusb /bin/true
+install bluetooth /bin/false
+install btusb /bin/false
 
 # Blacklist thunderbolt and firewire to prevent some DMA attacks.
-install thunderbolt /bin/true
-install firewire-core /bin/true
-install firewire_core /bin/true
-install firewire-ohci /bin/true
-install firewire_ohci /bin/true
-install ohci1394 /bin/true
-install sbp2 /bin/true
-install dv1394 /bin/true
-install raw1394 /bin/true
-install video1394 /bin/true
-install firewire-sbp2 /bin/true
+install thunderbolt /bin/false
+install firewire-core /bin/false
+install firewire_core /bin/false
+install firewire-ohci /bin/false
+install firewire_ohci /bin/false
+install ohci1394 /bin/false
+install sbp2 /bin/false
+install dv1394 /bin/false
+install raw1394 /bin/false
+install video1394 /bin/false
+install firewire-sbp2 /bin/false
 
 # Blacklist CPU MSRs as they can be abused to write to
 # arbitrary memory.
-install msr /bin/true
+install msr /bin/false
 
 # Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 #
@@ -36,41 +36,41 @@ install msr /bin/true
 #
 # > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
 #
-install dccp /bin/true
-install sctp /bin/true
-install rds /bin/true
-install tipc /bin/true
-install n-hdlc /bin/true
-install ax25 /bin/true
-install netrom /bin/true
-install x25 /bin/true
-install rose /bin/true
-install decnet /bin/true
-install econet /bin/true
-install af_802154 /bin/true
-install ipx /bin/true
-install appletalk /bin/true
-install psnap /bin/true
-install p8023 /bin/true
-install p8022 /bin/true
-install can /bin/true
-install atm /bin/true
+install dccp /bin/false
+install sctp /bin/false
+install rds /bin/false
+install tipc /bin/false
+install n-hdlc /bin/false
+install ax25 /bin/false
+install netrom /bin/false
+install x25 /bin/false
+install rose /bin/false
+install decnet /bin/false
+install econet /bin/false
+install af_802154 /bin/false
+install ipx /bin/false
+install appletalk /bin/false
+install psnap /bin/false
+install p8023 /bin/false
+install p8022 /bin/false
+install can /bin/false
+install atm /bin/false
 
 # Disable uncommon file systems to reduce attack surface
-install cramfs /bin/true
-install freevxfs /bin/true
-install jffs2 /bin/true
-install hfs /bin/true
-install hfsplus /bin/true
-install udf /bin/true
+install cramfs /bin/false
+install freevxfs /bin/false
+install jffs2 /bin/false
+install hfs /bin/false
+install hfsplus /bin/false
+install udf /bin/false
 
 # Disable uncommon network filesystems to reduce attack surface
-install cifs /bin/true
-install nfs /bin/true
-install nfsv3 /bin/true
-install nfsv4 /bin/true
-install ksmbd /bin/true
-install gfs2 /bin/true
+install cifs /bin/false
+install nfs /bin/false
+install nfsv3 /bin/false
+install nfsv4 /bin/false
+install ksmbd /bin/false
+install gfs2 /bin/false
 
 ## Blacklists the vivid kernel module as it's only required for
 ## testing and has been the cause of multiple vulnerabilities.
@@ -78,12 +78,12 @@ install gfs2 /bin/true
 ## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 ## https://www.openwall.com/lists/oss-security/2019/11/02/1
 ## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
-install vivid /bin/true
+install vivid /bin/false
 
 # Disable CD-ROM
-install cdrom /bin/true
-install sr_mod /bin/true
+install cdrom /bin/false
+install sr_mod /bin/false
 
 # Disable Intel Management Engine (ME) interface with OS
-install mei /bin/true
-install mei-me /bin/true
+install mei /bin/false
+install mei-me /bin/false

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -12,8 +12,17 @@ install bluetooth /bin/false
 install btusb /bin/false
 
 # Blacklist thunderbolt and firewire to prevent some DMA attacks.
-install firewire-core /bin/false
 install thunderbolt /bin/false
+install firewire-core /bin/false
+install firewire_core /bin/false
+install firewire-ohci /bin/false
+install firewire_ohci /bin/false
+install ohci1394 /bin/false
+install sbp2 /bin/false
+install dv1394 /bin/false
+install raw1394 /bin/false
+install video1394 /bin/false
+install firewire-sbp2 /bin/false
 
 # Blacklist CPU MSRs as they can be abused to write to
 # arbitrary memory.
@@ -47,9 +56,21 @@ install p8022 /bin/false
 install can /bin/false
 install atm /bin/false
 
-# Disable uncommon filesystems to reduce attack surface
+# Disable uncommon file systems to reduce attack surface
 install cramfs /bin/false
+install freevxfs /bin/false
+install jffs2 /bin/false
+install hfs /bin/false
+install hfsplus /bin/false
 install udf /bin/false
+
+# Disable uncommon network filesystems to reduce attack surface
+install cifs /bin/false
+install nfs /bin/false
+install nfsv3 /bin/false
+install nfsv4 /bin/false
+install ksmbd /bin/false
+install gfs2 /bin/false
 
 ## Blacklists the vivid kernel module as it's only required for
 ## testing and has been the cause of multiple vulnerabilities.
@@ -58,3 +79,11 @@ install udf /bin/false
 ## https://www.openwall.com/lists/oss-security/2019/11/02/1
 ## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
 install vivid /bin/false
+
+# Disable CD-ROM
+install cdrom /bin/false
+install sr_mod /bin/false
+
+# Disable Intel Management Engine (ME) interface with OS
+install mei /bin/false
+install mei-me /bin/false

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -8,25 +8,25 @@ options nf_conntrack nf_conntrack_helper=0
 # Bluetooth also has a history of security vulnerabilities:
 #
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
-install bluetooth /bin/false
-install btusb /bin/false
+install bluetooth /bin/true
+install btusb /bin/true
 
 # Blacklist thunderbolt and firewire to prevent some DMA attacks.
-install thunderbolt /bin/false
-install firewire-core /bin/false
-install firewire_core /bin/false
-install firewire-ohci /bin/false
-install firewire_ohci /bin/false
-install ohci1394 /bin/false
-install sbp2 /bin/false
-install dv1394 /bin/false
-install raw1394 /bin/false
-install video1394 /bin/false
-install firewire-sbp2 /bin/false
+install thunderbolt /bin/true
+install firewire-core /bin/true
+install firewire_core /bin/true
+install firewire-ohci /bin/true
+install firewire_ohci /bin/true
+install ohci1394 /bin/true
+install sbp2 /bin/true
+install dv1394 /bin/true
+install raw1394 /bin/true
+install video1394 /bin/true
+install firewire-sbp2 /bin/true
 
 # Blacklist CPU MSRs as they can be abused to write to
 # arbitrary memory.
-install msr /bin/false
+install msr /bin/true
 
 # Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 #
@@ -36,41 +36,41 @@ install msr /bin/false
 #
 # > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
 #
-install dccp /bin/false
-install sctp /bin/false
-install rds /bin/false
-install tipc /bin/false
-install n-hdlc /bin/false
-install ax25 /bin/false
-install netrom /bin/false
-install x25 /bin/false
-install rose /bin/false
-install decnet /bin/false
-install econet /bin/false
-install af_802154 /bin/false
-install ipx /bin/false
-install appletalk /bin/false
-install psnap /bin/false
-install p8023 /bin/false
-install p8022 /bin/false
-install can /bin/false
-install atm /bin/false
+install dccp /bin/true
+install sctp /bin/true
+install rds /bin/true
+install tipc /bin/true
+install n-hdlc /bin/true
+install ax25 /bin/true
+install netrom /bin/true
+install x25 /bin/true
+install rose /bin/true
+install decnet /bin/true
+install econet /bin/true
+install af_802154 /bin/true
+install ipx /bin/true
+install appletalk /bin/true
+install psnap /bin/true
+install p8023 /bin/true
+install p8022 /bin/true
+install can /bin/true
+install atm /bin/true
 
 # Disable uncommon file systems to reduce attack surface
-install cramfs /bin/false
-install freevxfs /bin/false
-install jffs2 /bin/false
-install hfs /bin/false
-install hfsplus /bin/false
-install udf /bin/false
+install cramfs /bin/true
+install freevxfs /bin/true
+install jffs2 /bin/true
+install hfs /bin/true
+install hfsplus /bin/true
+install udf /bin/true
 
 # Disable uncommon network filesystems to reduce attack surface
-install cifs /bin/false
-install nfs /bin/false
-install nfsv3 /bin/false
-install nfsv4 /bin/false
-install ksmbd /bin/false
-install gfs2 /bin/false
+install cifs /bin/true
+install nfs /bin/true
+install nfsv3 /bin/true
+install nfsv4 /bin/true
+install ksmbd /bin/true
+install gfs2 /bin/true
 
 ## Blacklists the vivid kernel module as it's only required for
 ## testing and has been the cause of multiple vulnerabilities.
@@ -78,12 +78,12 @@ install gfs2 /bin/false
 ## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 ## https://www.openwall.com/lists/oss-security/2019/11/02/1
 ## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
-install vivid /bin/false
+install vivid /bin/true
 
 # Disable CD-ROM
-install cdrom /bin/false
-install sr_mod /bin/false
+install cdrom /bin/true
+install sr_mod /bin/true
 
 # Disable Intel Management Engine (ME) interface with OS
-install mei /bin/false
-install mei-me /bin/false
+install mei /bin/true
+install mei-me /bin/true

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -11,24 +11,24 @@ options nf_conntrack nf_conntrack_helper=0
 
 # Blacklist bluetooth to reduce attack surface due to extended history of security vulnerabilities
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
-install bluetooth /bin/false
-install btusb /bin/false
+install bluetooth /bin/disabled-by-security-misc
+install btusb /bin/disabled-by-security-misc
 
 # Blacklist thunderbolt and firewire modules to prevent some DMA attacks
-install thunderbolt /bin/false
-install firewire-core /bin/false
-install firewire_core /bin/false
-install firewire-ohci /bin/false
-install firewire_ohci /bin/false
-install ohci1394 /bin/false
-install sbp2 /bin/false
-install dv1394 /bin/false
-install raw1394 /bin/false
-install video1394 /bin/false
-install firewire-sbp2 /bin/false
+install thunderbolt /bin/disabled-by-security-misc
+install firewire-core /bin/disabled-by-security-misc
+install firewire_core /bin/disabled-by-security-misc
+install firewire-ohci /bin/disabled-by-security-misc
+install firewire_ohci /bin/disabled-by-security-misc
+install ohci1394 /bin/disabled-by-security-misc
+install sbp2 /bin/disabled-by-security-misc
+install dv1394 /bin/disabled-by-security-misc
+install raw1394 /bin/disabled-by-security-misc
+install video1394 /bin/disabled-by-security-misc
+install firewire-sbp2 /bin/disabled-by-security-misc
 
 # Blacklist CPU MSRs as they can be abused to write to arbitrary memory.
-install msr /bin/false
+install msr /bin/disabled-by-security-misc
 
 # Blacklists unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 #
@@ -38,54 +38,54 @@ install msr /bin/false
 #
 # > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
 #
-install dccp /bin/false
-install sctp /bin/false
-install rds /bin/false
-install tipc /bin/false
-install n-hdlc /bin/false
-install ax25 /bin/false
-install netrom /bin/false
-install x25 /bin/false
-install rose /bin/false
-install decnet /bin/false
-install econet /bin/false
-install af_802154 /bin/false
-install ipx /bin/false
-install appletalk /bin/false
-install psnap /bin/false
-install p8023 /bin/false
-install p8022 /bin/false
-install can /bin/false
-install atm /bin/false
+install dccp /bin/disabled-by-security-misc
+install sctp /bin/disabled-by-security-misc
+install rds /bin/disabled-by-security-misc
+install tipc /bin/disabled-by-security-misc
+install n-hdlc /bin/disabled-by-security-misc
+install ax25 /bin/disabled-by-security-misc
+install netrom /bin/disabled-by-security-misc
+install x25 /bin/disabled-by-security-misc
+install rose /bin/disabled-by-security-misc
+install decnet /bin/disabled-by-security-misc
+install econet /bin/disabled-by-security-misc
+install af_802154 /bin/disabled-by-security-misc
+install ipx /bin/disabled-by-security-misc
+install appletalk /bin/disabled-by-security-misc
+install psnap /bin/disabled-by-security-misc
+install p8023 /bin/disabled-by-security-misc
+install p8022 /bin/disabled-by-security-misc
+install can /bin/disabled-by-security-misc
+install atm /bin/disabled-by-security-misc
 
 # Blacklist uncommon file systems to reduce attack surface
-install cramfs /bin/false
-install freevxfs /bin/false
-install jffs2 /bin/false
-install hfs /bin/false
-install hfsplus /bin/false
-install udf /bin/false
+install cramfs /bin/disabled-by-security-misc
+install freevxfs /bin/disabled-by-security-misc
+install jffs2 /bin/disabled-by-security-misc
+install hfs /bin/disabled-by-security-misc
+install hfsplus /bin/disabled-by-security-misc
+install udf /bin/disabled-by-security-misc
 
 # Blacklist uncommon network file systems to reduce attack surface
-install cifs /bin/false
-install nfs /bin/false
-install nfsv3 /bin/false
-install nfsv4 /bin/false
-install ksmbd /bin/false
-install gfs2 /bin/false
+install cifs /bin/disabled-by-security-misc
+install nfs /bin/disabled-by-security-misc
+install nfsv3 /bin/disabled-by-security-misc
+install nfsv4 /bin/disabled-by-security-misc
+install ksmbd /bin/disabled-by-security-misc
+install gfs2 /bin/disabled-by-security-misc
 
 # Blacklists the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
 # https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 # https://www.openwall.com/lists/oss-security/2019/11/02/1
 # https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
-install vivid /bin/false
+install vivid /bin/disabled-by-security-misc
 
 # Blacklist CD-ROM devices
 # https://nvd.nist.gov/vuln/detail/CVE-2018-11506
-install cdrom /bin/false
-install sr_mod /bin/false
+install cdrom /bin/disabled-by-security-misc
+install sr_mod /bin/disabled-by-security-misc
 
 # Blacklist Intel Management Engine (ME) interface with the OS
 # https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
-install mei /bin/false
-install mei-me /bin/false
+install mei /bin/disabled-by-security-misc
+install mei-me /bin/disabled-by-security-misc

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -1,17 +1,20 @@
 ## Copyright (C) 2012 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## https://phabricator.whonix.org/T486
+# See the following links for a community discussion and overview regarding the selections
+# https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989
+# https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules
+
+# Blacklist automatic conntrack helper assignment
+# https://phabricator.whonix.org/T486
 options nf_conntrack nf_conntrack_helper=0
 
-# Blacklists bluetooth to reduce attack surface.
-# Bluetooth also has a history of security vulnerabilities:
-#
+# Blacklist bluetooth to reduce attack surface due to extended history of security vulnerabilities
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
 install bluetooth /bin/false
 install btusb /bin/false
 
-# Blacklist thunderbolt and firewire to prevent some DMA attacks.
+# Blacklist thunderbolt and firewire modules to prevent some DMA attacks
 install thunderbolt /bin/false
 install firewire-core /bin/false
 install firewire_core /bin/false
@@ -24,11 +27,10 @@ install raw1394 /bin/false
 install video1394 /bin/false
 install firewire-sbp2 /bin/false
 
-# Blacklist CPU MSRs as they can be abused to write to
-# arbitrary memory.
+# Blacklist CPU MSRs as they can be abused to write to arbitrary memory.
 install msr /bin/false
 
-# Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
+# Blacklists unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 #
 # Credit to Tails (https://tails.boum.org/blueprint/blacklist_modules/) for some of these.
 #
@@ -56,7 +58,7 @@ install p8022 /bin/false
 install can /bin/false
 install atm /bin/false
 
-# Disable uncommon file systems to reduce attack surface
+# Blacklist uncommon file systems to reduce attack surface
 install cramfs /bin/false
 install freevxfs /bin/false
 install jffs2 /bin/false
@@ -64,7 +66,7 @@ install hfs /bin/false
 install hfsplus /bin/false
 install udf /bin/false
 
-# Disable uncommon network filesystems to reduce attack surface
+# Blacklist uncommon network file systems to reduce attack surface
 install cifs /bin/false
 install nfs /bin/false
 install nfsv3 /bin/false
@@ -72,18 +74,18 @@ install nfsv4 /bin/false
 install ksmbd /bin/false
 install gfs2 /bin/false
 
-## Blacklists the vivid kernel module as it's only required for
-## testing and has been the cause of multiple vulnerabilities.
-##
-## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
-## https://www.openwall.com/lists/oss-security/2019/11/02/1
-## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
+# Blacklists the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
+# https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
+# https://www.openwall.com/lists/oss-security/2019/11/02/1
+# https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
 install vivid /bin/false
 
-# Disable CD-ROM
+# Blacklist CD-ROM devices
+# https://nvd.nist.gov/vuln/detail/CVE-2018-11506
 install cdrom /bin/false
 install sr_mod /bin/false
 
-# Disable Intel Management Engine (ME) interface with OS
+# Blacklist Intel Management Engine (ME) interface with the OS
+# https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 install mei /bin/false
 install mei-me /bin/false

--- a/usr/bin/disabled-by-security-misc
+++ b/usr/bin/disabled-by-security-misc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1


### PR DESCRIPTION
Further increased quantity and type of modules blacklisted. The majority are unlikely to be used by the typical user and in cumulative represent a large attack surface reduction especially against more legacy approaches.

Open to feedback.

In summary:
- Increased protections against DMA attacks using more obscure firewire modules,
- Disabled more uncommon file systems that should not conflict with whonix requirements,
- Disabled a variety of uncommon network file systems,
- Disabled use of CD-ROM by default as the technology seems to be all but disappearing, and
- Intel CPUs might glow less brightly in the dark with some ME blocking (https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html).

https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules
https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989
https://security.stackexchange.com/questions/4098/how-to-disable-firewire-in-openbsd-linux-to-prevent-attacks-through-firewire
https://linux-audit.com/kernel-hardening-disable-and-blacklist-linux-modules/

Finally, the use of /bin/false should perhaps be replaced with /bin/true.

This does not appear to impact whonix users but users from other distributions could benefit from this increased compatibility by avoiding log errors when using this code.

https://github.com/ComplianceAsCode/content/issues/539