### PR TITLE
Incorporated Ubuntu’s kernel module blacklists and more verbose errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,23 @@ disabled.
 
 * IOMMU is enabled to prevent DMA attacks.
 
-### Blacklisted kernel modules
+### Disables and blacklists kernel modules
 
-Certain kernel modules are blacklisted to reduce attack surface via the
+Certain kernel modules are disabled and blacklisted by default to reduce attack surface via the
 `/etc/modprobe.d/30_security-misc.conf` configuration file.
 
 * Deactivates Netfilter's connection tracking helper - this module
 increases kernel attack surface by enabling superfluous functionality
 such as IRC parsing in the kernel. Hence, this feature is disabled.
+
+* Bluetooth is disabled to reduce attack surface. Bluetooth has
+a lengthy history of security concerns.
+
+* Thunderbolt and numerous FireWire kernel modules are also disabled as they are
+often vulnerable to DMA attacks.
+
+* The MSR kernel module is disabled to prevent CPU MSRs from being
+abused to write to arbitrary memory.
 
 * Uncommon network protocols are blacklisted. This includes:
 
@@ -137,23 +146,16 @@ such as IRC parsing in the kernel. Hence, this feature is disabled.
 
  ATM
 
-* Bluetooth is also blacklisted to reduce attack surface. Bluetooth has
-a history of security concerns.
-
-* The Thunderbolt and FireWire kernel modules are blacklisted as they are
-often vulnerable to DMA attacks.
-
-* The vivid kernel module is only required for testing and has been the cause
-of multiple vulnerabilities so it is blacklisted.
-
-* The MSR kernel module is blacklisted to prevent CPU MSRs from being
-abused to write to arbitrary memory.
-
 * Disables a large array of uncommon file systems and network file systems that reduces the attack surface especially against legacy approaches.
 
-* Provides some blocking of the interface between the [Intel Management Engine (ME)](https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html) and the OS.
+* The vivid kernel module is only required for testing and has been the cause
+of multiple vulnerabilities so it is disabled.
 
-* Not enabled by default yet, comment only: Disables the use of CD-ROM devices by default.
+* Provides some disabling of the interface between the [Intel Management Engine (ME)](https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html) and the OS.
+
+* Incorporates much of [Ubuntu's](https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d?h=ubuntu/disco) default blacklist of modules to be blocked from automatically loading. However, they are  still permitted to load.
+
+* Blocks automatic loading of the modules needed to use of CD-ROM devices by default. Not completely disabled yet.
 
 ### Other
 

--- a/bin/disabled-module-by-security-misc/block-bluetooth
+++ b/bin/disabled-module-by-security-misc/block-bluetooth
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This bluetooth kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-cdrom
+++ b/bin/disabled-module-by-security-misc/block-cdrom
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This CD-ROM kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-filesys
+++ b/bin/disabled-module-by-security-misc/block-filesys
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-firewire
+++ b/bin/disabled-module-by-security-misc/block-firewire
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This firewire kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-intelme
+++ b/bin/disabled-module-by-security-misc/block-intelme
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This Intel Management Engine (ME) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-msr
+++ b/bin/disabled-module-by-security-misc/block-msr
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This CPU MSR kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-netfilesys
+++ b/bin/disabled-module-by-security-misc/block-netfilesys
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This network file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-network
+++ b/bin/disabled-module-by-security-misc/block-network
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This network protocol kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-thunderbolt
+++ b/bin/disabled-module-by-security-misc/block-thunderbolt
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This thunderbolt kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/bin/disabled-module-by-security-misc/block-vivid
+++ b/bin/disabled-module-by-security-misc/block-vivid
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2019 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This vivid kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc.conf | args: $@" >&2
+
+exit 1

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -11,77 +11,77 @@ options nf_conntrack nf_conntrack_helper=0
 
 ## Disable bluetooth to reduce attack surface due to extended history of security vulnerabilities
 ## https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
-install bluetooth /bin/disabled-by-security-misc
-install btusb /bin/disabled-by-security-misc
+install bluetooth /bin/disabled-module-by-security-misc/block-bluetooth
+install btusb /bin/disabled-module-by-security-misc/block-bluetooth
 
 ## Disable thunderbolt and firewire modules to prevent some DMA attacks
-install thunderbolt /bin/disabled-by-security-misc
-install firewire-core /bin/disabled-by-security-misc
-install firewire_core /bin/disabled-by-security-misc
-install firewire-ohci /bin/disabled-by-security-misc
-install firewire_ohci /bin/disabled-by-security-misc
-install firewire_sbp2 /bin/disabled-by-security-misc
-install firewire-sbp2 /bin/disabled-by-security-misc
-install ohci1394 /bin/disabled-by-security-misc
-install sbp2 /bin/disabled-by-security-misc
-install dv1394 /bin/disabled-by-security-misc
-install raw1394 /bin/disabled-by-security-misc
-install video1394 /bin/disabled-by-security-misc
+install thunderbolt /bin/disabled-module-by-security-misc/block-thunderbolt
+install firewire-core /bin/disabled-module-by-security-misc/block-firewire
+install firewire_core /bin/disabled-module-by-security-misc/block-firewire
+install firewire-ohci /bin/disabled-module-by-security-misc/block-firewire
+install firewire_ohci /bin/disabled-module-by-security-misc/block-firewire
+install firewire_sbp2 /bin/disabled-module-by-security-misc/block-firewire
+install firewire-sbp2 /bin/disabled-module-by-security-misc/block-firewire
+install ohci1394 /bin/disabled-module-by-security-misc/block-firewire
+install sbp2 /bin/disabled-module-by-security-misc/block-firewire
+install dv1394 /bin/disabled-module-by-security-misc/block-firewire
+install raw1394 /bin/disabled-module-by-security-misc/block-firewire
+install video1394 /bin/disabled-module-by-security-misc/block-firewire
 
 ## Disable CPU MSRs as they can be abused to write to arbitrary memory.
 ## https://security.stackexchange.com/questions/119712/methods-root-can-use-to-elevate-itself-to-kernel-mode
-install msr /bin/disabled-by-security-misc
+install msr /bin/disabled-module-by-security-misc/block-msr
 
 ## Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 ## Credit to Tails (https://tails.boum.org/blueprint/blacklist_modules/) for some of these.
 ## > Debian ships a long list of modules for wide support of devices, filesystems, protocols. Some of these modules have a pretty bad security track record, and some of those are simply not used by most of our users.
 ## > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
-install dccp /bin/disabled-by-security-misc
-install sctp /bin/disabled-by-security-misc
-install rds /bin/disabled-by-security-misc
-install tipc /bin/disabled-by-security-misc
-install n-hdlc /bin/disabled-by-security-misc
-install ax25 /bin/disabled-by-security-misc
-install netrom /bin/disabled-by-security-misc
-install x25 /bin/disabled-by-security-misc
-install rose /bin/disabled-by-security-misc
-install decnet /bin/disabled-by-security-misc
-install econet /bin/disabled-by-security-misc
-install af_802154 /bin/disabled-by-security-misc
-install ipx /bin/disabled-by-security-misc
-install appletalk /bin/disabled-by-security-misc
-install psnap /bin/disabled-by-security-misc
-install p8023 /bin/disabled-by-security-misc
-install p8022 /bin/disabled-by-security-misc
-install can /bin/disabled-by-security-misc
-install atm /bin/disabled-by-security-misc
+install dccp /bin/disabled-module-by-security-misc/block-network
+install sctp /bin/disabled-module-by-security-misc/block-network
+install rds /bin/disabled-module-by-security-misc/block-network
+install tipc /bin/disabled-module-by-security-misc/block-network
+install n-hdlc /bin/disabled-module-by-security-misc/block-network
+install ax25 /bin/disabled-module-by-security-misc/block-network
+install netrom /bin/disabled-module-by-security-misc/block-network
+install x25 /bin/disabled-module-by-security-misc/block-network
+install rose /bin/disabled-module-by-security-misc/block-network
+install decnet /bin/disabled-module-by-security-misc/block-network
+install econet /bin/disabled-module-by-security-misc/block-network
+install af_802154 /bin/disabled-module-by-security-misc/block-network
+install ipx /bin/disabled-module-by-security-misc/block-network
+install appletalk /bin/disabled-module-by-security-misc/block-network
+install psnap /bin/disabled-module-by-security-misc/block-network
+install p8023 /bin/disabled-module-by-security-misc/block-network
+install p8022 /bin/disabled-module-by-security-misc/block-network
+install can /bin/disabled-module-by-security-misc/block-network
+install atm /bin/disabled-module-by-security-misc/block-network
 
 ## Disable uncommon file systems to reduce attack surface
-install cramfs /bin/disabled-by-security-misc
-install freevxfs /bin/disabled-by-security-misc
-install jffs2 /bin/disabled-by-security-misc
-install hfs /bin/disabled-by-security-misc
-install hfsplus /bin/disabled-by-security-misc
-install udf /bin/disabled-by-security-misc
+install cramfs /bin/disabled-module-by-security-misc/block-filesys
+install freevxfs /bin/disabled-module-by-security-misc/block-filesys
+install jffs2 /bin/disabled-module-by-security-misc/block-filesys
+install hfs /bin/disabled-module-by-security-misc/block-filesys
+install hfsplus /bin/disabled-module-by-security-misc/block-filesys
+install udf /bin/disabled-module-by-security-misc/block-filesys
 
 ## Disable uncommon network file systems to reduce attack surface
-install cifs /bin/disabled-by-security-misc
-install nfs /bin/disabled-by-security-misc
-install nfsv3 /bin/disabled-by-security-misc
-install nfsv4 /bin/disabled-by-security-misc
-install ksmbd /bin/disabled-by-security-misc
-install gfs2 /bin/disabled-by-security-misc
+install cifs /bin/disabled-module-by-security-misc/block-netfilesys
+install nfs /bin/disabled-module-by-security-misc/block-netfilesys
+install nfsv3 /bin/disabled-module-by-security-misc/block-netfilesys
+install nfsv4 /bin/disabled-module-by-security-misc/block-netfilesys
+install ksmbd /bin/disabled-module-by-security-misc/block-netfilesys
+install gfs2 /bin/disabled-module-by-security-misc/block-netfilesys
 
 ## Disables the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
 ## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 ## https://www.openwall.com/lists/oss-security/2019/11/02/1
 ## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
-install vivid /bin/disabled-by-security-misc
+install vivid /bin/disabled-module-by-security-misc/block-vivid
 
 ## Disable Intel Management Engine (ME) interface with the OS
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
-install mei /bin/disabled-by-security-misc
-install mei-me /bin/disabled-by-security-misc
+install mei /bin/disabled-module-by-security-misc/block-intelme
+install mei-me /bin/disabled-module-by-security-misc/block-intelme
 
 ## Blacklist automatic loading of the Atheros 5K RF MACs madwifi driver
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
@@ -139,7 +139,7 @@ blacklist udlfb
 ## Disable CD-ROM devices
 ## https://nvd.nist.gov/vuln/detail/CVE-2018-11506
 ## https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
-#install cdrom /bin/disabled-by-security-misc
-#install sr_mod /bin/disabled-by-security-misc
+#install cdrom /bin/disabled-module-by-security-misc/block-cdrom
+#install sr_mod /bin/disabled-module-by-security-misc/block-cdrom
 blacklist cdrom
 blacklist sr_mod

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -5,32 +5,33 @@
 # https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989
 # https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules
 
-# Blacklist automatic conntrack helper assignment
+# Disable automatic conntrack helper assignment
 # https://phabricator.whonix.org/T486
 options nf_conntrack nf_conntrack_helper=0
 
-# Blacklist bluetooth to reduce attack surface due to extended history of security vulnerabilities
+# Disable bluetooth to reduce attack surface due to extended history of security vulnerabilities
 # https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
 install bluetooth /bin/disabled-by-security-misc
 install btusb /bin/disabled-by-security-misc
 
-# Blacklist thunderbolt and firewire modules to prevent some DMA attacks
+# Disable thunderbolt and firewire modules to prevent some DMA attacks
 install thunderbolt /bin/disabled-by-security-misc
 install firewire-core /bin/disabled-by-security-misc
 install firewire_core /bin/disabled-by-security-misc
 install firewire-ohci /bin/disabled-by-security-misc
 install firewire_ohci /bin/disabled-by-security-misc
+install firewire_sbp2 /bin/disabled-by-security-misc
+install firewire-sbp2 /bin/disabled-by-security-misc
 install ohci1394 /bin/disabled-by-security-misc
 install sbp2 /bin/disabled-by-security-misc
 install dv1394 /bin/disabled-by-security-misc
 install raw1394 /bin/disabled-by-security-misc
 install video1394 /bin/disabled-by-security-misc
-install firewire-sbp2 /bin/disabled-by-security-misc
 
-# Blacklist CPU MSRs as they can be abused to write to arbitrary memory.
+# Disable CPU MSRs as they can be abused to write to arbitrary memory.
 install msr /bin/disabled-by-security-misc
 
-# Blacklists unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
+# Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
 #
 # Credit to Tails (https://tails.boum.org/blueprint/blacklist_modules/) for some of these.
 #
@@ -58,7 +59,7 @@ install p8022 /bin/disabled-by-security-misc
 install can /bin/disabled-by-security-misc
 install atm /bin/disabled-by-security-misc
 
-# Blacklist uncommon file systems to reduce attack surface
+# Disable uncommon file systems to reduce attack surface
 install cramfs /bin/disabled-by-security-misc
 install freevxfs /bin/disabled-by-security-misc
 install jffs2 /bin/disabled-by-security-misc
@@ -66,7 +67,7 @@ install hfs /bin/disabled-by-security-misc
 install hfsplus /bin/disabled-by-security-misc
 install udf /bin/disabled-by-security-misc
 
-# Blacklist uncommon network file systems to reduce attack surface
+# Disable uncommon network file systems to reduce attack surface
 install cifs /bin/disabled-by-security-misc
 install nfs /bin/disabled-by-security-misc
 install nfsv3 /bin/disabled-by-security-misc
@@ -74,18 +75,71 @@ install nfsv4 /bin/disabled-by-security-misc
 install ksmbd /bin/disabled-by-security-misc
 install gfs2 /bin/disabled-by-security-misc
 
-# Blacklists the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
+# Disables the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
 # https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 # https://www.openwall.com/lists/oss-security/2019/11/02/1
 # https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
 install vivid /bin/disabled-by-security-misc
 
-# Blacklist Intel Management Engine (ME) interface with the OS
+# Disable Intel Management Engine (ME) interface with the OS
 # https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 install mei /bin/disabled-by-security-misc
 install mei-me /bin/disabled-by-security-misc
 
-# Blacklist CD-ROM devices
+# Blacklist automatic loading of the Atheros 5K RF MACs madwifi driver
+# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
+blacklist ath_pci
+
+# Blacklist automatic loading of miscellaneous modules
+# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
+blacklist evbug
+blacklist usbmouse
+blacklist usbkbd
+blacklist eepro100
+blacklist de4x5
+blacklist eth1394
+blacklist snd_intel8x0m
+blacklist snd_aw2
+blacklist prism54
+blacklist bcm43xx
+blacklist garmin_gps
+blacklist asus_acpi
+blacklist snd_pcsp
+blacklist pcspkr
+blacklist amd76x_edac
+
+# Blacklist automatic loading of framebuffer drivers
+# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
+blacklist aty128fb
+blacklist atyfb
+# blacklist radeonfb
+blacklist cirrusfb
+blacklist cyber2000fb
+blacklist cyblafb
+blacklist gx1fb
+blacklist hgafb
+blacklist i810fb
+# blacklist intelfb
+blacklist kyrofb
+blacklist lxfb
+blacklist matroxfb_base
+blacklist neofb
+# blacklist nvidiafb
+blacklist pm2fb
+blacklist rivafb
+blacklist s1d13xxxfb
+blacklist savagefb
+blacklist sisfb
+blacklist sstfb
+blacklist tdfxfb
+blacklist tridentfb
+# blacklist vesafb
+blacklist vfb
+blacklist viafb
+blacklist vt8623fb
+blacklist udlfb
+
+# Disable CD-ROM devices
 # https://nvd.nist.gov/vuln/detail/CVE-2018-11506
 # https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
 #install cdrom /bin/disabled-by-security-misc

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -144,3 +144,5 @@ blacklist udlfb
 # https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
 #install cdrom /bin/disabled-by-security-misc
 #install sr_mod /bin/disabled-by-security-misc
+blacklist cdrom
+blacklist sr_mod

--- a/etc/modprobe.d/30_security-misc.conf
+++ b/etc/modprobe.d/30_security-misc.conf
@@ -1,20 +1,20 @@
 ## Copyright (C) 2012 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-# See the following links for a community discussion and overview regarding the selections
-# https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989
-# https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules
+## See the following links for a community discussion and overview regarding the selections
+## https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989
+## https://madaidans-insecurities.github.io/guides/linux-hardening.html#kasr-kernel-modules
 
-# Disable automatic conntrack helper assignment
-# https://phabricator.whonix.org/T486
+## Disable automatic conntrack helper assignment
+## https://phabricator.whonix.org/T486
 options nf_conntrack nf_conntrack_helper=0
 
-# Disable bluetooth to reduce attack surface due to extended history of security vulnerabilities
-# https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
+## Disable bluetooth to reduce attack surface due to extended history of security vulnerabilities
+## https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
 install bluetooth /bin/disabled-by-security-misc
 install btusb /bin/disabled-by-security-misc
 
-# Disable thunderbolt and firewire modules to prevent some DMA attacks
+## Disable thunderbolt and firewire modules to prevent some DMA attacks
 install thunderbolt /bin/disabled-by-security-misc
 install firewire-core /bin/disabled-by-security-misc
 install firewire_core /bin/disabled-by-security-misc
@@ -28,17 +28,14 @@ install dv1394 /bin/disabled-by-security-misc
 install raw1394 /bin/disabled-by-security-misc
 install video1394 /bin/disabled-by-security-misc
 
-# Disable CPU MSRs as they can be abused to write to arbitrary memory.
+## Disable CPU MSRs as they can be abused to write to arbitrary memory.
+## https://security.stackexchange.com/questions/119712/methods-root-can-use-to-elevate-itself-to-kernel-mode
 install msr /bin/disabled-by-security-misc
 
-# Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
-#
-# Credit to Tails (https://tails.boum.org/blueprint/blacklist_modules/) for some of these.
-#
-# > Debian ships a long list of modules for wide support of devices, filesystems, protocols. Some of these modules have a pretty bad security track record, and some of those are simply not used by most of our users.
-#
-# > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
-#
+## Disables unneeded network protocols that will likely not be used as these may have unknown vulnerabilties.
+## Credit to Tails (https://tails.boum.org/blueprint/blacklist_modules/) for some of these.
+## > Debian ships a long list of modules for wide support of devices, filesystems, protocols. Some of these modules have a pretty bad security track record, and some of those are simply not used by most of our users.
+## > Other distributions like Ubuntu[1] and Fedora[2] already ship a blacklist for various network protocols which aren't much in use by users and have a poor security track record.
 install dccp /bin/disabled-by-security-misc
 install sctp /bin/disabled-by-security-misc
 install rds /bin/disabled-by-security-misc
@@ -59,7 +56,7 @@ install p8022 /bin/disabled-by-security-misc
 install can /bin/disabled-by-security-misc
 install atm /bin/disabled-by-security-misc
 
-# Disable uncommon file systems to reduce attack surface
+## Disable uncommon file systems to reduce attack surface
 install cramfs /bin/disabled-by-security-misc
 install freevxfs /bin/disabled-by-security-misc
 install jffs2 /bin/disabled-by-security-misc
@@ -67,7 +64,7 @@ install hfs /bin/disabled-by-security-misc
 install hfsplus /bin/disabled-by-security-misc
 install udf /bin/disabled-by-security-misc
 
-# Disable uncommon network file systems to reduce attack surface
+## Disable uncommon network file systems to reduce attack surface
 install cifs /bin/disabled-by-security-misc
 install nfs /bin/disabled-by-security-misc
 install nfsv3 /bin/disabled-by-security-misc
@@ -75,23 +72,23 @@ install nfsv4 /bin/disabled-by-security-misc
 install ksmbd /bin/disabled-by-security-misc
 install gfs2 /bin/disabled-by-security-misc
 
-# Disables the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
-# https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
-# https://www.openwall.com/lists/oss-security/2019/11/02/1
-# https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
+## Disables the vivid kernel module as it's only required for testing and has been the cause of multiple vulnerabilities
+## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
+## https://www.openwall.com/lists/oss-security/2019/11/02/1
+## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
 install vivid /bin/disabled-by-security-misc
 
-# Disable Intel Management Engine (ME) interface with the OS
-# https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
+## Disable Intel Management Engine (ME) interface with the OS
+## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 install mei /bin/disabled-by-security-misc
 install mei-me /bin/disabled-by-security-misc
 
-# Blacklist automatic loading of the Atheros 5K RF MACs madwifi driver
-# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
+## Blacklist automatic loading of the Atheros 5K RF MACs madwifi driver
+## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
 blacklist ath_pci
 
-# Blacklist automatic loading of miscellaneous modules
-# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
+## Blacklist automatic loading of miscellaneous modules
+## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
 blacklist evbug
 blacklist usbmouse
 blacklist usbkbd
@@ -108,23 +105,23 @@ blacklist snd_pcsp
 blacklist pcspkr
 blacklist amd76x_edac
 
-# Blacklist automatic loading of framebuffer drivers
-# https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
+## Blacklist automatic loading of framebuffer drivers
+## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
 blacklist aty128fb
 blacklist atyfb
-# blacklist radeonfb
+#blacklist radeonfb
 blacklist cirrusfb
 blacklist cyber2000fb
 blacklist cyblafb
 blacklist gx1fb
 blacklist hgafb
 blacklist i810fb
-# blacklist intelfb
+#blacklist intelfb
 blacklist kyrofb
 blacklist lxfb
-blacklist matroxfb_base
+blacklist matroxfb_bases
 blacklist neofb
-# blacklist nvidiafb
+#blacklist nvidiafb
 blacklist pm2fb
 blacklist rivafb
 blacklist s1d13xxxfb
@@ -133,15 +130,15 @@ blacklist sisfb
 blacklist sstfb
 blacklist tdfxfb
 blacklist tridentfb
-# blacklist vesafb
+#blacklist vesafb
 blacklist vfb
 blacklist viafb
 blacklist vt8623fb
 blacklist udlfb
 
-# Disable CD-ROM devices
-# https://nvd.nist.gov/vuln/detail/CVE-2018-11506
-# https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
+## Disable CD-ROM devices
+## https://nvd.nist.gov/vuln/detail/CVE-2018-11506
+## https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
 #install cdrom /bin/disabled-by-security-misc
 #install sr_mod /bin/disabled-by-security-misc
 blacklist cdrom


### PR DESCRIPTION
Building on the successfully merged PR [#109](https://github.com/Kicksecure/security-misc/pull/109), goal is to add a plethora of more kernel modules to be blacklisted by default based largely on the Ubuntu defaults.

https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d?h=ubuntu/disco 
https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/13
 
Overall, this blacklists their automatic loading but does NOT permanently disable them  in order to reduce the likelihood of compatibility issues. 

I am not deeply familiar with the intricacies of each of these modules and so if others in the community are more knowledgeable, maybe we could begin permanently disabling them over time just to be safe. 

Furthermore, due to intended future compatibility with ISOs, we [decided](https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/30) not to disable CD-ROM by default. Instead what if we simply blacklist the modules so they are only loaded on demand?

Also as there is a strict distinction between “disable” permanently and “blacklist” automatic loading, the comments were also correspondingly updated. Perhaps we should make is difference clearer throughout the whole project?