### PR TITLE
/usr mounting

### DIFF
--- a/apt/apt.conf.d/usr-security-misc
+++ b/apt/apt.conf.d/usr-security-misc
@@ -1,0 +1,2 @@
+Dpkg::Pre-Invoke {"mount -o remount,nodev,rw /usr";};
+Dpkg::Post-Invoke {"mount -o remount,nodev,ro /usr";};

--- a/usr/bin/remount-secure
+++ b/usr/bin/remount-secure
@@ -211,6 +211,13 @@ _home() {
    remount_secure
 }
 
+_usr() {
+#  needs testing
+#  mount_folder="$NEWROOT/usr"
+#  intended_mount_options="ro,nodev"
+#  remount_secure "$@"
+}
+
 end() {
    ## Debugging.
    $output_command "INFO: 'findmnt --list' output at the END."


### PR DESCRIPTION
/usr mounting. with the newly added files, usr has to have been mounted before invoking apt, because apt is going to try to remount it. so not having it mounted will cause error. it would be mounted if the section in remount-secure works.