### PR TITLE
Fix double mount issue for /var/log and /var/tmp

### DIFF
--- a/usr/bin/remount-secure
+++ b/usr/bin/remount-secure
@@ -232,14 +232,6 @@ _tmp() {
    remount_secure
 }
 
-_var() {
-   mount_folder="$NEWROOT/var"
-   ## noexec: Not possible. Reason:
-   ## Debian stores executable maintainer scripts in /var/lib/dpkg/info folder.
-   intended_mount_options="nosuid,nodev"
-   remount_secure
-}
-
 _var_tmp() {
    mount_folder="$NEWROOT/var/tmp"
    intended_mount_options="nosuid,nodev${most_noexec_maybe}"
@@ -249,6 +241,14 @@ _var_tmp() {
 _var_log() {
    mount_folder="$NEWROOT/var/log"
    intended_mount_options="nosuid,nodev,noexec"
+   remount_secure
+}
+
+_var() {
+   mount_folder="$NEWROOT/var"
+   ## noexec: Not possible. Reason:
+   ## Debian stores executable maintainer scripts in /var/lib/dpkg/info folder.
+   intended_mount_options="nosuid,nodev"
    remount_secure
 }
 
@@ -289,9 +289,9 @@ main() {
    _dev
    _dev_shm
    _tmp
-   _var
    _var_tmp
    _var_log
+   _var
    _home
 
    end


### PR DESCRIPTION
Mounting var with bind and mounting a subdirectory causes /var/tmp and /var/log bind mounted twice each. can be checked with lsblk. When we bind mount var only after having mounted the subdirectories, everything is mounted only one.