### PR TITLE
Restrict access to compilers

### DIFF
--- a/etc/permission-hardening.d/30_compilers.conf
+++ b/etc/permission-hardening.d/30_compilers.conf
@@ -1,0 +1,5 @@
+/usr/bin/as 0700 root root
+/usr/bin/g++ 0700 root root
+/usr/bin/gcc 0700 root root
+/usr/bin/cc 0700 root root
+/usr/bin/clang 0700 root root


### PR DESCRIPTION
This can also be implemented as a script pair. ```lock_compiler``` and  ```lock_compiler_undo``` with only root having access to these. Then it might be easier to use compilers without root when needed. But this does not remove functionality anyway. We sould just have to ```sudo gcc```.