### PR TITLE
Depend on libpam-tmpdir for very solid extra security

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Rules-Requires-Root: no
 Package: security-misc
 Architecture: all
 Depends: python3, libglib2.0-bin, libpam-runtime, sudo, adduser, libcap2-bin,
- apparmor-profile-dist, helper-scripts, libpam-modules-bin,
+ apparmor-profile-dist, helper-scripts, libpam-modules-bin, libpam-tmpdir,
  secure-delete, dmsetup, ${misc:Depends}
 Replaces: tcp-timestamps-disable, anon-gpg-tweaks, swappiness-lowest
 Description: Enhances Miscellaneous Security Settings

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Rules-Requires-Root: no
 
 Package: security-misc
 Architecture: all
-Replaces: tcp-timestamps-disable, anon-gpg-tweaks, swappiness-lowest
 Depends: adduser,
          apparmor-profile-dist,
          dmsetup,


### PR DESCRIPTION
I am not quite sure if this would be the right way to add a dependency. But we should definetely depend on this package.

https://packages.debian.org/bookworm/libpam-tmpdir
>Many programs use $TMPDIR for storing temporary files. Not all of them are good at securing the permissions of those files. libpam-tmpdir sets $TMPDIR and $TMP for PAM sessions and sets the permissions quite tight. This helps system security by having an extra layer of security, making such symlink attacks and other /tmp based attacks harder or impossible.