### PR TITLE
Harden the loading of new modules to the kernel after install

### DIFF
--- a/debian/security-misc.postinst
+++ b/debian/security-misc.postinst
@@ -61,6 +61,8 @@ pam-auth-update --package
 /usr/libexec/security-misc/permission-lockdown
 permission_hardening
 
+systemctl enable disable-module-loading.service
+
 ## https://phabricator.whonix.org/T377
 ## Debian has no update-grub trigger yet:
 ## https://bugs.debian.org/481542

--- a/debian/security-misc.postinst
+++ b/debian/security-misc.postinst
@@ -61,8 +61,6 @@ pam-auth-update --package
 /usr/libexec/security-misc/permission-lockdown
 permission_hardening
 
-systemctl enable disable-module-loading.service
-
 ## https://phabricator.whonix.org/T377
 ## Debian has no update-grub trigger yet:
 ## https://bugs.debian.org/481542

--- a/lib/systemd/system/harden-module-loading.service
+++ b/lib/systemd/system/harden-module-loading.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Disable the loading of modules to the kernel after startup. This could be malicious.
+After=systemd-modules-load.service
+# This functionality is implemented with this and not directly in the sysctl config is
+# to allow systemd-modules-load.service to load the modules with no problem but
+# to disallow anyone else do the same after the system boots up.
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/security-misc/disable-kernel-module-loading
+
+[Install]
+WantedBy=sysinit.target

--- a/lib/systemd/system/harden-module-loading.service
+++ b/lib/systemd/system/harden-module-loading.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Disable the loading of modules to the kernel after startup. This could be malicious.
 After=systemd-modules-load.service
+Before=sysinit.target
 # This functionality is implemented with this and not directly in the sysctl config is
 # to allow systemd-modules-load.service to load the modules with no problem but
 # to disallow anyone else do the same after the system boots up.

--- a/usr/libexec/security-misc/disable-kernel-module-loading
+++ b/usr/libexec/security-misc/disable-kernel-module-loading
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sysctl -w kernel.modules_disabled=1
+
+echo "The loading of new modules to the kernel has been disabled by security-misc" >&2

--- a/usr/libexec/security-misc/disable-kernel-module-loading
+++ b/usr/libexec/security-misc/disable-kernel-module-loading
@@ -2,4 +2,4 @@
 
 sysctl -w kernel.modules_disabled=1
 
-echo "The loading of new modules to the kernel has been disabled by security-misc" >&2
+echo "The loading of new modules to the kernel has been disabled by security-misc"


### PR DESCRIPTION
Normally it is recommended to have ```kernel.modules_disabled``` set to ```1```. This is the case for all hardened systems, where they pre-define all the modules to be loaded if any. This prevents the loading of new modules to the kernel. Having this set as a sysctl configuration breaks the system, because it also denies ```systemd-modules-load.service``` the ability to load the modules that are legitemately needed. I found a workaround. I created a systemd service. It triggers on start up but only after ```systemd-modules-load.service``` has already done its thing. Then it disables the loading of new modules to the kernel by setting the aforementioned kernel variable. The system is fully functional.

The only scenario where this would be somewhat inconvenient is maybe if and only if the following exact things happen: 
* a user starts up the system
* some peripheral he uses needs drivers that is in the kernel
* the drivers are kind of niche so they don't get loaded by default
* and this device is not plugged in when the system is booting
* so the drivers for that peripheral don't load
* and the user decides to use this peripheral afterwards and plugs it
* and the drivers cannot load, because we disabled it
 
But if everything is plugged in on system startup, nothing can break even in such an edge scenario, I think.

There are some stuff I am not sure of. First of all, it works as is perfectly. I put the service under ```lib/systemd/system/harden-module-loading.service``` and the executable that sets the kernel variable in ```usr/libexec/security-misc/disable-kernel-module-loading```. If another path is more desirable for the executable, we can change that. I also enable the service after install by adding the line ```systemctl enable disable-module-loading.service``` into the file ```debian/security-misc.postinst```. I am not sure if this would be right method of enabling the service. If it needs to be taken care of somewhere else, this can also be fixed.