### PR TITLE
Fix unmount error - This time real

### DIFF
--- a/lib/systemd/system/var.mount
+++ b/lib/systemd/system/var.mount
@@ -1,0 +1,3 @@
+[Unit]
+Requires=var-log.mount var-tmp.mount
+After=var-log.mount var-tmp.mount


### PR DESCRIPTION
I tested everything. Works like charm. Fixed. No slowdown no drawback. True and real. I just added a unit for ```var.mount``` in ```lib/systemd/system```, that makes sure ```/var``` is unmounted before ```/var/log``` and ```/var/tmp```. And my guess was true, it was the ordering that cauesd the issue. When they are unmounted in the correct order, no errors occur. Var has to be unmounted first. And this file makes sure of that.