### PR TITLE
Disable SysRq by default

### DIFF
--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -137,11 +137,8 @@ net.ipv4.tcp_timestamps=0
 #### meta end
 
 
-## Only allow the SysRq key to be used for shutdowns and the
-## Secure Attention Key (SAK).
-##
-## https://forums.whonix.org/t/sysrq-magic-sysrq-key/8079/
-kernel.sysrq=132
+## Disable SysRq key
+kernel.sysrq=0
 
 ## Restrict loading TTY line disciplines to CAP_SYS_MODULE to prevent
 ## unprivileged attackers from loading vulnerable line disciplines


### PR DESCRIPTION
I have read the thread and I can see why you chose the leave [SysRq enabled for reboot/poweroff](https://www.kernel.org/doc/html/latest/admin-guide/sysrq.html). I'll see your situation and I'll raise you a situation. Having the SysRq value fixed at 128 is, tho better than 1, not that poqerful. Firstly, we provide those with local access infinite debugging capabilities, and some real capabilities.
>It is a 'magical' key combo you can hit which the kernel will respond to regardless of whatever else it is doing, unless it is completely locked up.

And more over, we get no real benefit from it. 
* Firstly, we dont even use it regularly, at least for the expected use cases here, let's be honest. This is no magical automatic protection. Do you use SysRq to kill every process ever except your current console before logging in? Probably not if you are on a desktop environment.
* Secondly, we don't need to use it, anyway. It is 2023. Long gone are the days where random schmos could spy on your keyboard strokes. On wayland, no one can spy on your password key strokes anyway. And this is a real solid solution. Migrating to wayland. 

Random theoretical work arounds like this bring no real benefit at all because:
* it is no good if you don't use the functionality
* if you always use it, your life will be very impractical
* if you want to use it when you suspect you have malware, well, since malware does not announce itself, you are really not protected from anything unless you preemptively know when there is malware, which if you can do that, you probably don't need this

Theoretically yes, this can be a useful, maybe when you are recovering a system. But this is also very unlikely to happen, and there are other, infinetely more secure methods of recovering your system, like livebooting. Also what you discuss in the thread, which is login spoofing on the login screen, is already really unlikely and very difficult to pull off anyway. There is literally nothing running at that point. Something like a rootkit would be capable of such a threat. And a serious and real protection against that is not enabling SysRq and hoping you would preemptively recognize it, but rather using verified boot.

And for the use case we leave here, which is shutting the system down with a key combo, I also don't see no need for. If you need magical key combo to shutdown, it is the poweroff button. There are of course certain benefits to doing it this way and stuff but as I said, I don't see these miniscule benefits outweighing the downsides.

I might be wrong. If I actually am wrong, please correct me. Convince me why this is better. But I think my points stand.