### PR TITLE
Add more hardening options to the default profile in etc

### DIFF
--- a/etc/profile.d/30_security-misc.sh
+++ b/etc/profile.d/30_security-misc.sh
@@ -14,3 +14,11 @@ if [ -x /usr/libexec/security-misc/panic-on-oops ]; then
    ## Hide output. Otherwise could confuse Qubes UpdatesProxy.
    sudo --non-interactive /usr/libexec/security-misc/panic-on-oops 1>/dev/null 2>/dev/null
 fi
+
+# Set the default umask 0077. Whatever the access value the umask value is subtracted from it. Subtracting 7 means stripping
+# all capabilities. This means that new files and folders created by a user will have no permission for group and others. 
+umask 0077
+
+## Once again disable core dumps by limiting the coredump file size to 0.
+## One of the many places we disable coredumps in this package.
+ulimit -c 0


### PR DESCRIPTION
Disabling coredumps and setting a secure umask value. Comments explain more in detail. I am really sorry for the many pull requests, this is the last one. I don't mean to spam the project. They are mostly really small but significant changes. I thought that it would be easier to manage for the maintainer if they are seperated.