### PR TITLE
USB Guard | Depend on it and configure rules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Depends: adduser,
          python3,
          secure-delete,
          sudo,
+         usbguard,
          ${misc:Depends}
 Replaces: anon-gpg-tweaks, swappiness-lowest, tcp-timestamps-disable
 Description: Enhances Miscellaneous Security Settings

--- a/etc/usbguard/rules.d/30_security-misc.conf
+++ b/etc/usbguard/rules.d/30_security-misc.conf
@@ -1,0 +1,18 @@
+## Blacklisting is not the optimal approach to security. Normally all USB devices should be rejected (default) and only the devices you personally know and trust be whitelisted.
+## If you can do this, it is recommended to do. For convenience for the majority, we do the following:
+
+## Allow all USB devices with mass storage interface
+allow with-interface equals { 08:*:* }
+
+## Reject storage devices that also have extra suspicuous interfaces.
+## Like a usb storage device that also tries to behave like a keyboard.
+## This is a well known type of cyber attack.
+
+reject with-interface all-of { 08:*:* 03:00:* }
+reject with-interface all-of { 08:*:* 03:01:* }
+reject with-interface all-of { 08:*:* e0:*:* }
+reject with-interface all-of { 08:*:* 0a:*:* }
+reject with-interface all-of { 08:*:* 02:*:* }
+
+## We do not allow anything else. Keyboards, mice, and everything else, they will be rejected. The only exception is, if they were plugged in when the daemon starts.
+## If you have your keyboard plugged in before booting, it will be allowed. If you plug after the fact, you have to manually allow the device or do a restart.


### PR DESCRIPTION
We should depend on usbguard as a package. When installed on debian, usb guard settings are configured in a way that all devices are rejected, only those that were already plugged in before the daemon starts are allowed.

Normally this is not optimal. We should by default reject everything and only whitelist the devices that we know and trust. But this requires configuration at the user end. So for now, we better leave the debian config as is.

We also add new rules with our config file. These rules do not configure the daemon. They define how the daemon behaves when it is 'applying policy'. The policy is by default blocking everything. We slacken this by allowing devices with mass storage interface, so the users can plug in their external hard drives and usb's. Then we blacklist especially suspicuous storage devices. Those that try to also behave like a keyboard at the same time for example.

Normally this is also not optimal, but it is a big improvement. We don't allow anything else. That means everything else is implicitly blocked. If the user plugs in a keyboard or mouse or anything else, it will be blocked. If these devices are plugged in when the machine starts up, they are allowed. This should not be too inconvenient for the user, because most peripherals are almost always already plugged in when the machine starts up. If not, they can be manually allowed or the system can be rebooted for the device to be allowed after having booted.