### PR TITLE
Small systemd hardening

### DIFF
--- a/lib/systemd/system.conf.d/30_security-misc.conf
+++ b/lib/systemd/system.conf.d/30_security-misc.conf
@@ -1,0 +1,6 @@
+[Manager]
+DumpCore=no
+## Allow no non-native calls as these may be used to circumvent some security protections
+## For example 32 bit x86 code is executable in modern 64 bit x86 systems because of backwards
+## compatibility. This is undesirable and can potentially be dangerous.
+SystemCallArchitectures=native


### PR DESCRIPTION
Just allow native architecture calls. From what I understand, 32 bit binaries would not benefit from ASLR due to the incredibly small address space and might cause other programs to have less effective ASLR too. Apparently this can also cause other security issues and it is in general recommended not to execute anything non-native.

Also once again core dump.