### PR TITLE
Iommu Kernel Parameters

### DIFF
--- a/etc/default/grub.d/40_enable_iommu.cfg
+++ b/etc/default/grub.d/40_enable_iommu.cfg
@@ -14,4 +14,4 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX efi=disable_early_pci_dma"
 ## Enables strict enforcement of IOMMU TLB invalidation so devices will never be able to access stale data contents
 ## https://github.com/torvalds/linux/blob/master/drivers/iommu/Kconfig#L97
 ## Page 11 of https://lenovopress.lenovo.com/lp1467.pdf
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu=strict iommu.passthrough=0 iommu.strict=1"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu=force iommu.passthrough=0 iommu.strict=1"

--- a/etc/default/grub.d/40_enable_iommu.cfg
+++ b/etc/default/grub.d/40_enable_iommu.cfg
@@ -2,7 +2,7 @@
 ## See the file COPYING for copying conditions.
 
 ## Enables IOMMU to prevent DMA attacks.
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX intel_iommu=on amd_iommu=on"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX intel_iommu=on amd_iommu=force_enable iommu=strict iommu.strict=1 iommu.passthrough=0"
 
 ## Disable the busmaster bit on all PCI bridges during very
 ## early boot to avoid holes in IOMMU.

--- a/etc/default/grub.d/40_enable_iommu.cfg
+++ b/etc/default/grub.d/40_enable_iommu.cfg
@@ -2,7 +2,7 @@
 ## See the file COPYING for copying conditions.
 
 ## Enables IOMMU to prevent DMA attacks.
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX intel_iommu=on amd_iommu=force_enable iommu=strict iommu.strict=1 iommu.passthrough=0"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX intel_iommu=on amd_iommu=force_enable"
 
 ## Disable the busmaster bit on all PCI bridges during very
 ## early boot to avoid holes in IOMMU.
@@ -14,4 +14,4 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX efi=disable_early_pci_dma"
 ## Enables strict enforcement of IOMMU TLB invalidation so devices will never be able to access stale data contents
 ## https://github.com/torvalds/linux/blob/master/drivers/iommu/Kconfig#L97
 ## Page 11 of https://lenovopress.lenovo.com/lp1467.pdf
-GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0 iommu.strict=1"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu=strict iommu.passthrough=0 iommu.strict=1"


### PR DESCRIPTION
What we already have in place ```amd_iommu=on``` is not a thing. It is not a valid options. See [here](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html?highlight=amd_iommu). A valid and hardened options would be ```force_enable```. While we are at it, we can also set ```iommu=force``` to disable bypasses for pci devices.