### PR TITLE
Disable asynchronous I/O

### DIFF
--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -67,6 +67,9 @@ kernel.randomize_va_space=2
 kernel.unprivileged_bpf_disabled=1
 net.core.bpf_jit_harden=2
 
+## Disable asynchronous I/O for all processes.
+kernel.io_uring_disabled=2
+
 #### meta start
 #### project Kicksecure
 #### category networking and security


### PR DESCRIPTION
io_uring creation is disabled for all processes. io_uring_setup always fails with -EPERM. Existing io_uring instances can still be used.

https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html

https://forums.whonix.org/t/io-uring-security-vulnerabilties/16890/4