### PR TITLE
Hardened Malloc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Depends: adduser,
          python3,
          secure-delete,
          sudo,
+         hardened-malloc,
          ${misc:Depends}
 Replaces: anon-gpg-tweaks, swappiness-lowest, tcp-timestamps-disable
 Description: Enhances Miscellaneous Security Settings

--- a/usr/lib/systemd/system.conf.d/50_security-misc.conf
+++ b/usr/lib/systemd/system.conf.d/50_security-misc.conf
@@ -1,0 +1,4 @@
+[Manager]
+DefaultEnvironment="LD_PRELOAD='libhardened_malloc.so'"
+SystemCallArchitectures=native
+DumpCore=no

--- a/usr/lib/systemd/user.conf.c/50_security-misc.conf
+++ b/usr/lib/systemd/user.conf.c/50_security-misc.conf
@@ -1,0 +1,4 @@
+[Manager]
+DefaultEnvironment="LD_PRELOAD='libhardened_malloc.so'"
+SystemCallArchitectures=native
+DumpCore=no


### PR DESCRIPTION
Depends on hardened malloc and enables it for all system and user services as default. User applications are thus unaffected, like web browsers etc. Most sensitive and vulnerable OS components use hardened malloc and are hardened against memory corruption and heap exploits.