### PR TITLE
Umask Settings

### DIFF
--- a/etc/profile.d/30_security-misc-umask.sh
+++ b/etc/profile.d/30_security-misc-umask.sh
@@ -1,0 +1,6 @@
+if [ "$(id -u)" -eq 0 ]
+then
+    umask 077
+else
+    umask 022
+fi

--- a/usr/share/pam-configs/mkhomedir-security-misc
+++ b/usr/share/pam-configs/mkhomedir-security-misc
@@ -4,4 +4,4 @@ Priority: 100
 Session-Type: Additional
 Session-Interactive-Only: yes
 Session:
-	optional	pam_mkhomedir.so umask=027
+	optional	pam_mkhomedir.so umask=0077

--- a/usr/share/pam-configs/umask-security-misc
+++ b/usr/share/pam-configs/umask-security-misc
@@ -1,0 +1,8 @@
+Name: Restrict umask to 0077 (by package security-misc)
+Default: yes
+Priority: 100
+Session-Type: Additional
+Session-Interactive-Only: yes
+Session:
+	[success=1 default=ignore]	pam_succeed_if.so uid eq 0
+	optional	pam_umask.so umask=0077


### PR DESCRIPTION
Set umask as 0077 for all users and services using the pam module. Then override this by setting the umask 0022 for ```root``` under ```/etc/environment.d/```. Any valid use case where having a umask of 0077 can be problematic is thus covered and not included in the hardening. System administrators will have this umask when they login.