### PR TITLE
Mount Secure

### DIFF
--- a/etc/default/grub.d/40_secure-mount.cfg
+++ b/etc/default/grub.d/40_secure-mount.cfg
@@ -1,0 +1,11 @@
+# tmp and api file systems
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX systemd.mount-extra=tmpfs:/tmp:[:tmpfs[:defaults,nodev,nosuid,noexec]]"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX systemd.mount-extra=udev:/dev:[:devtmpfs[:defaults,nosuid,noexec]]"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX systemd.mount-extra=tmpfs:/dev/shm:[:tmpfs[:defaults,nodev,nosuid,noexec]]"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX systemd.mount-extra=tmpfs:/run:[:tmpfs[:defaults,nodev,nosuid,noexec]]"
+#
+#
+## Also binds can be done in this manner
+## But how do know for sure that we can bind for example var to itself? We can't do it if var has a dedicated partitoin on disk.
+## Have to find a way to make sure there is no partition before binding anything
+## Possible to use if else in kernel command line?

--- a/etc/systemd/system/boot-efi.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/boot-efi.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/boot.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/boot.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/home.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/home.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid

--- a/etc/systemd/system/tmp.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/tmp.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/usr-share.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/usr-share.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid

--- a/etc/systemd/system/usr.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/usr.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev

--- a/etc/systemd/system/var-log-audit.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/var-log-audit.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/var-log.mount.d
+++ b/etc/systemd/system/var-log.mount.d
@@ -1,2 +1,0 @@
-[Mount]
-Options=nodev,nosuid,noexec

--- a/etc/systemd/system/var-log.mount.d
+++ b/etc/systemd/system/var-log.mount.d
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/var-log.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/var-log.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/var-tmp.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/var-tmp.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid,noexec

--- a/etc/systemd/system/var.mount.d/50_security-misc.conf
+++ b/etc/systemd/system/var.mount.d/50_security-misc.conf
@@ -1,0 +1,2 @@
+[Mount]
+Options=nodev,nosuid


### PR DESCRIPTION
Good old mount secure that works with all systems and configs.

Only downside: no bind mounting when no partition on disk. We can actually do this, but before it, we have to make sure that there is no dediated partition for what we want to bind. So if there is a way to determine that within kernel command line, we can also bind mount things.