### PR TITLE
Secure Bind Mount & Protect Hardware

### DIFF
--- a/usr/bin/secure-bind-protect-hardware
+++ b/usr/bin/secure-bind-protect-hardware
@@ -1,0 +1,30 @@
+#!/bin/bash
+mount --options defaults,nosuid,nodev --bind --make-private /opt /opt
+mount --options defaults,nosuid,nodev --bind --make-private /home /home
+mount --options defaults,nodev,nosuid --bind --make-private /tmp /tmp
+mount --options defaults,nodev,nosuid,noexec --bind --make-private /boot/efi /boot/efi
+mount --options defaults,nodev,noosuid,noexec --bind --make-private /boot /boot
+mount --options defaults,nodev --bind --make-private /usr /usr
+mount --options defaults,nosuid,nodev --bind --make-private /var /var
+mount --options defaults,nosuid,nodev,noexec --bind --make-private /etc /etc
+mount --options defaults,nosuid,nodev,noexec --bind --make-private /srv /srv
+mount --options defaults,nosuid,nodev,noexec --bind --make-private /root /root
+mount --options defaults,nosuid,nodev,noexec --bind --make-private /media /media
+mount --options defaults,nosuid,nodev --bind --make-private /mnt /mnt
+mount --options defaults,nosuid,nodev,noexec,remount,subset=pid /proc
+mount --options defaults,nosuid,nodev,noexec,remount /sys
+mount --options defaults,nosuid,nodev,noexec,remount /run
+mount --options defaults,nosuid,nodev,noexec,remount /dev/shm
+mount --options defaults,nosuid,noexec,remount /dev
+
+chmod 0500 /sys/block
+#chmod 0500 /sys/class
+#chmod 0500 /sys/devices
+#chmod 0500 /sys/fs
+chmod 0500 /sys/kernel
+chmod 0500 /sys/power
+chmod 0500 /sys/bus
+#chmod 0500 /sys/dev
+chmod 0500 /sys/firmware
+chmod 0500 /sys/hypervisor
+chmod 0500 /sys/module

--- a/usr/lib/systemd/system/secure-bind-protect-hardware.service
+++ b/usr/lib/systemd/system/secure-bind-protect-hardware.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Securely bind directories to themselves with hardened mount options, remount api filesystems with hardened options, secure sensitive and volative non-persistent filesystems
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/secure-bind-protect-hardware
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello. This pull request resolves two currently open issues. One is protecting hardware by limiting access to /proc and /sys. Well good news. I present you the best way possible. Mounting proc with subset=pid ensure that only the pid subset under proc is visible, everything else is invisible. This is also the case for root. No one can see anything. ```/proc/dma```, ```/proc/iomem```, ```/proc/ioports```, ```/proc/meminfo```, ```/proc/kallsyms```, ```/proc/kcore``` and literally tons of other stuff, everything protected even from root. Just ```ls /proc``` to see for yourself what gets hidden.

When it comes to /sys, [starting based on this comment](https://github.com/Kicksecure/security-misc/issues/172#issuecomment-1951419805), I found the sources of breakages. The comment is true, but not complete, because there are also other subsets that break too, apart from just fs. Those are enabled, and everything else is disabled. Tested.

And bind mounting. You said not having bind mounts is a big deal. You said binds are important, they are our lives. Well. You say no more. I give you binds, a lot of them, and them only. At this point, we might as well just bind everything, disregarding if it has a proper real partition. Because even if it does have a partition, bind mounting to itself does no harm literally. The overhead seems to be really really minimal and unnoticable. So this is the current suggestion. Test for yourself and report please.