### PR TITLE
BHI mitigation on Intel CPUs

### DIFF
--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -75,3 +75,8 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX retbleed=auto,nosmt"
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/srso.html
 
+## Enables mitigation of Branch History Injection vulnerabilities on Intel CPUs.
+##
+## https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2bb69f5fc72183e1c62547d900f560d0e9334925
+## TODO: update the above link with better alternative when possible
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_bhi=on"


### PR DESCRIPTION
Add kernel parameter for new Intel CPU vulnerability.

https://lore.kernel.org/lkml/20220714195236.9311-1-daniel.sneddon@linux.intel.com/
https://www.vusec.net/projects/native-bhi/

This kernel parameter is preemptive and will only take effect once the fixes are backported. LTS kernel version 6.1.85 and above are patched.