### PR TITLE
fix(etc): delete typo in /etc/apparmor.d tunables

### DIFF
--- a/etc/apparmor.d/tunables/home.d/security-misc
+++ b/etc/apparmor.d/tunables/home.d/security-misc
@@ -1,7 +1,7 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-alias /etc/pam.d/common-session -> /etc/pam.d//etc/pam.d/common-session.security-misc,
+alias /etc/pam.d/common-session -> /etc/pam.d/common-session.security-misc,
 alias /etc/pam.d/common-session-noninteractive -> /etc/pam.d/common-session-noninteractive.security-misc,
 alias /etc/login.defs -> /etc/login.defs.security-misc,
 alias /etc/securetty -> /etc/securetty.security-misc,


### PR DESCRIPTION
/etc/pam.d was present twice in a row (/etc/pam.d//etc/pam.d) in this file: /etc/apparmor.d/tunables/home.d/security-misc.