### PR TITLE
Update presentation of  `/etc/modprobe.d/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ modules from automatically starting.
 Specific kernel modules are entirely disabled to reduce attack surface via
 `/etc/modprobe.d/30_security-misc_disable.conf`. Disabling prohibits kernel
 modules from starting. This approach should not be considered comprehensive,
-rather it is a form of badness enumeration.
+rather it is a form of badness enumeration. Any potential candidates for future
+disabling should first be blacklisted for a suitable amount of time.
 
 -   File Systems: Disable uncommon and legacy file systems.
 

--- a/README.md
+++ b/README.md
@@ -124,15 +124,15 @@ modules for the user, like drivers etc., given they are plugged in on startup.
 
 #### Blacklist and disable kernel modules
 
+Conntrack: Deactivates Netfilter's connection tracking helper module which
+increases kernel attack surface by enabling superfluous functionality such
+as IRC parsing in the kernel. See `/etc/modprobe.d/30_security-misc_conntrack.conf`.
+
 Certain kernel modules are blacklisted by default to reduce attack surface via
 `/etc/modprobe.d/30_security-misc_blacklist.conf`. Blacklisting prevents kernel
 modules from automatically starting.
 
 -   CD-ROM/DVD: Blacklist modules required for CD-ROM/DVD devices.
-
--   Conntrack: Deactivates Netfilter's connection tracking helper - this module
-    increases kernel attack surface by enabling superfluous functionality such
-    as IRC parsing in the kernel. Hence, this feature is disabled.
 
 -   Framebuffer Drivers: Blacklisted as they are well-known to be buggy, cause 
     kernel panics, and are generally only used by legacy devices. 

--- a/debian/security-misc.maintscript
+++ b/debian/security-misc.maintscript
@@ -24,7 +24,7 @@ rm_conffile /etc/sysctl.d/kexec.conf
 rm_conffile /etc/sysctl.d/tcp_hardening.conf
 rm_conffile /etc/sysctl.d/tcp_sack.conf
 
-## merged into 2 files /etc/modprobe.d/30_security-misc_blacklist.conf and /etc/modprobe.d/30_security-misc_disable.conf
+## merged into 3 files /etc/modprobe.d/30_security-misc_blacklist.conf, 30_security-misc_conntrack.conf, and /etc/modprobe.d/30_security-misc_disable.conf
 rm_conffile /etc/modprobe.d/uncommon-network-protocols.conf
 rm_conffile /etc/modprobe.d/blacklist-bluetooth.conf
 rm_conffile /etc/modprobe.d/vivid.conf

--- a/etc/modprobe.d/30_security-misc_blacklist.conf
+++ b/etc/modprobe.d/30_security-misc_blacklist.conf
@@ -11,24 +11,27 @@
 ## CD-ROM/DVD:
 ## Blacklist CD-ROM and DVD modules.
 ## Do not disable by default for potential future ISO plans.
+##
 ## https://nvd.nist.gov/vuln/detail/CVE-2018-11506
 ## https://forums.whonix.org/t/blacklist-more-kernel-modules-to-reduce-attack-surface/7989/31
-#
+##
 blacklist cdrom
 blacklist sr_mod
-#
+##
 #install cdrom /usr/bin/disabled-cdrom-by-security-misc
 #install sr_mod /usr/bin/disabled-cdrom-by-security-misc
 
 ## Conntrack:
 ## Disable automatic conntrack helper assignment.
+##
 ## https://phabricator.whonix.org/T486
-#
+##
 options nf_conntrack nf_conntrack_helper=0
 
 ## Framebuffer Drivers:
+##
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
-#
+##
 blacklist aty128fb
 blacklist atyfb
 blacklist cirrusfb
@@ -59,9 +62,10 @@ blacklist vt8623fb
 blacklist udlfb
 
 ## Miscellaneous:
+##
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
-#
+##
 blacklist ath_pci
 blacklist amd76x_edac
 blacklist asus_acpi

--- a/etc/modprobe.d/30_security-misc_blacklist.conf
+++ b/etc/modprobe.d/30_security-misc_blacklist.conf
@@ -21,13 +21,6 @@ blacklist sr_mod
 #install cdrom /usr/bin/disabled-cdrom-by-security-misc
 #install sr_mod /usr/bin/disabled-cdrom-by-security-misc
 
-## Conntrack:
-## Disable automatic conntrack helper assignment.
-##
-## https://phabricator.whonix.org/T486
-##
-options nf_conntrack nf_conntrack_helper=0
-
 ## Framebuffer Drivers:
 ##
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco

--- a/etc/modprobe.d/30_security-misc_conntrack.conf
+++ b/etc/modprobe.d/30_security-misc_conntrack.conf
@@ -1,0 +1,11 @@
+## Copyright (C) 2012 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Conntrack:
+## Disable Netfilter's automatic connection tracking helper assignment.
+## Increases kernel attack surface by enabling superfluous functionality such as IRC parsing in the kernel.
+##
+## https://conntrack-tools.netfilter.org/manual.html
+## https://forums.whonix.org/t/disable-conntrack-helper/18917
+##
+options nf_conntrack nf_conntrack_helper=0

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -10,24 +10,26 @@
 
 ## Bluetooth:
 ## Disable Bluetooth to reduce attack surface due to extended history of security vulnerabilities.
+##
 ## https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
-#
+##
 ## Now replaced by a privacy and security preserving default Bluetooth configuration for better usability.
-#
+##
 #install bluetooth /usr/bin/disabled-bluetooth-by-security-misc
 #install btusb /usr/bin/disabled-bluetooth-by-security-misc
 
 ## CPU Model-Specific Registers (MSRs):
 ## Disable CPU MSRs as they can be abused to write to arbitrary memory.
+##
 ## https://security.stackexchange.com/questions/119712/methods-root-can-use-to-elevate-itself-to-kernel-mode
 ## https://github.com/Kicksecure/security-misc/issues/215
-#
+##
 #install msr /usr/bin/disabled-msr-by-security-misc
 
 ## File Systems:
 ## Disable uncommon file systems to reduce attack surface.
 ## HFS and HFS+ are legacy Apple filesystems that may be required depending on the EFI partition format.
-#
+##
 install cramfs /usr/bin/disabled-filesys-by-security-misc
 install freevxfs /usr/bin/disabled-filesys-by-security-misc
 install hfs /usr/bin/disabled-filesys-by-security-misc
@@ -37,8 +39,9 @@ install udf /usr/bin/disabled-filesys-by-security-misc
 
 ## FireWire (IEEE 1394):
 ## Disable IEEE 1394 (FireWire/i.LINK/Lynx) modules to prevent some DMA attacks.
+##
 ## https://en.wikipedia.org/wiki/IEEE_1394#Security_issues
-#
+##
 install dv1394 /usr/bin/disabled-firewire-by-security-misc
 install firewire-core /usr/bin/disabled-firewire-by-security-misc
 install firewire-ohci /usr/bin/disabled-firewire-by-security-misc
@@ -51,7 +54,7 @@ install video1394 /usr/bin/disabled-firewire-by-security-misc
 
 ## Global Positioning Systems (GPS):
 ## Disable GPS-related modules like GNSS (Global Navigation Satellite System).
-#
+##
 install gnss /usr/bin/disabled-gps-by-security-misc
 install gnss-mtk /usr/bin/disabled-gps-by-security-misc
 install gnss-serial /usr/bin/disabled-gps-by-security-misc
@@ -61,14 +64,15 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 
 ## Intel Management Engine (ME):
 ## Partially disable the Intel ME interface with the OS.
+##
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
-#
+##
 install mei /usr/bin/disabled-intelme-by-security-misc
 install mei-me /usr/bin/disabled-intelme-by-security-misc
 
 ## Network File Systems:
 ## Disable uncommon network file systems to reduce attack surface.
-#
+##
 install cifs /usr/bin/disabled-netfilesys-by-security-misc
 install gfs2 /usr/bin/disabled-netfilesys-by-security-misc
 install ksmbd /usr/bin/disabled-netfilesys-by-security-misc
@@ -78,10 +82,11 @@ install nfsv4 /usr/bin/disabled-netfilesys-by-security-misc
 
 ## Network Protocols:
 ## Disables rare and unneeded network protocols that are a common source of unknown vulnerabilities.
+##
 ## https://tails.boum.org/blueprint/blacklist_modules/
 ## https://fedoraproject.org/wiki/Security_Features_Matrix#Blacklist_Rare_Protocols)
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-rare-network.conf?h=ubuntu/disco
-#
+##
 install af_802154 /usr/bin/disabled-network-by-security-misc
 install appletalk /usr/bin/disabled-network-by-security-misc
 install atm /usr/bin/disabled-network-by-security-misc
@@ -103,17 +108,19 @@ install tipc /usr/bin/disabled-network-by-security-misc
 install x25 /usr/bin/disabled-network-by-security-misc
 
 ## Miscellaneous:
-#
+##
 ## Vivid:
 ## Disables the vivid kernel module since it has been the cause of multiple vulnerabilities.
+##
 ## https://forums.whonix.org/t/kernel-recompilation-for-better-hardening/7598/233
 ## https://www.openwall.com/lists/oss-security/2019/11/02/1
 ## https://github.com/a13xp0p0v/kconfig-hardened-check/commit/981bd163fa19fccbc5ce5d4182e639d67e484475
-#
+##
 install vivid /usr/bin/disabled-vivid-by-security-misc
 
 ## Thunderbolt:
 ## Disables Thunderbolt modules to prevent some DMA attacks.
+##
 ## https://en.wikipedia.org/wiki/Thunderbolt_(interface)#Security_vulnerabilities
-#
+##
 install thunderbolt /usr/bin/disabled-thunderbolt-by-security-misc


### PR DESCRIPTION
Minor changes and improvements following PR https://github.com/Kicksecure/security-misc/pull/230.

In preparation for future planned changes.

## Changes

Moves the disabling of the `nf_conntrack_helper` module into a separate file `/etc/modprobe.d/30_security-misc_conntrack.conf`.

There are no changes to the actual functionality of the code.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it