### PR TITLE
Disable more Intel ME kernel modules

### DIFF
--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -68,7 +68,17 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 ##
 install mei /usr/bin/disabled-intelme-by-security-misc
+install mei-gsc /usr/bin/disabled-intelme-by-security-misc
+install mei_gsc_proxy /usr/bin/disabled-intelme-by-security-misc
+install mei_hdcp /usr/bin/disabled-intelme-by-security-misc
 install mei-me /usr/bin/disabled-intelme-by-security-misc
+install mei_phy /usr/bin/disabled-intelme-by-security-misc
+install mei_pxp /usr/bin/disabled-intelme-by-security-misc
+install mei-txe /usr/bin/disabled-intelme-by-security-misc
+install mei-vsc-hw /usr/bin/disabled-intelme-by-security-misc
+install mei-vsc /usr/bin/disabled-intelme-by-security-misc
+install mei_wdt /usr/bin/disabled-intelme-by-security-misc
+install microread_mei /usr/bin/disabled-intelme-by-security-misc
 
 ## Network File Systems:
 ## Disable uncommon network file systems to reduce attack surface.

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -64,8 +64,13 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 
 ## Intel Management Engine (ME):
 ## Partially disable the Intel ME interface with the OS.
+## ME functionality has increasing become more intertwined with basic system operation.
+## Disabling may lead to breakages places such as security, power management, display, and DRM.
 ##
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
+## https://en.wikipedia.org/wiki/Intel_Management_Engine#Security_vulnerabilities
+## https://www.kicksecure.com/wiki/Out-of-band_Management_Technology#Intel_ME_Disabling_Disadvantages
+## https://github.com/Kicksecure/security-misc/pull/236#issuecomment-2229092813
 ##
 install mei /usr/bin/disabled-intelme-by-security-misc
 install mei-gsc /usr/bin/disabled-intelme-by-security-misc
@@ -75,8 +80,8 @@ install mei-me /usr/bin/disabled-intelme-by-security-misc
 install mei_phy /usr/bin/disabled-intelme-by-security-misc
 install mei_pxp /usr/bin/disabled-intelme-by-security-misc
 install mei-txe /usr/bin/disabled-intelme-by-security-misc
-install mei-vsc-hw /usr/bin/disabled-intelme-by-security-misc
 install mei-vsc /usr/bin/disabled-intelme-by-security-misc
+install mei-vsc-hw /usr/bin/disabled-intelme-by-security-misc
 install mei_wdt /usr/bin/disabled-intelme-by-security-misc
 install microread_mei /usr/bin/disabled-intelme-by-security-misc
 


### PR DESCRIPTION
Disable more Intel Management Engine (ME) kernel modules.

## Changes

Add some Intel ME modules to the list of disabled kernel modules.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it