### PR TITLE
Disable some Intel PMT kernel modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ disabling should first be blacklisted for a suitable amount of time.
 -   Intel Management Engine (ME): Provides some disabling of the interface between the
     Intel ME and the OS.
 
+-   Intel Platform Monitoring Technology Telemetry (PMT): Disable some functionality
+    of the Intel PMT components.
+    
 -   Network File Systems: Disable uncommon and legacy network file systems.
 
 -   Network Protocols: Wide array of uncommon and legacy network protocols are disabled.

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -70,6 +70,15 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 install mei /usr/bin/disabled-intelme-by-security-misc
 install mei-me /usr/bin/disabled-intelme-by-security-misc
 
+## Intel Platform Monitoring Technology Telemetry (PMT):
+## Disable some functionality of the Intel PMT components.
+##
+## https://github.com/intel/Intel-PMT
+##
+install pmt_class /usr/bin/disabled-intelpmt-by-security-misc
+install pmt_crashlog /usr/bin/disabled-intelpmt-by-security-misc
+install pmt_telemetry /usr/bin/disabled-intelpmt-by-security-misc
+
 ## Network File Systems:
 ## Disable uncommon network file systems to reduce attack surface.
 ##

--- a/usr/bin/disabled-intelpmt-by-security-misc
+++ b/usr/bin/disabled-intelpmt-by-security-misc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2024 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This Intel Platform Monitoring Technology Telemetry (PMT) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+
+exit 1


### PR DESCRIPTION
Disable some Intel Platform Monitoring Technology Telemetry (PMT) kernel modules.

Disabling was first suggested in Issue https://github.com/Kicksecure/security-misc/issues/224.

## Changes

Add some Intel PMT modules to the list of disabled kernel modules.

Create `disabled-intelpmt-by-security-misc`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it