### PR TITLE
Remove obsolete `#net.ipv4.tcp_fack=0`

### DIFF
--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -297,10 +297,9 @@ net.ipv6.conf.default.accept_source_route=0
 net.ipv6.conf.all.accept_ra=0
 net.ipv6.conf.default.accept_ra=0
 
-## Disable SACK, DSACK, and FACK.
+## Disable SACK and DSACK.
 ## Select acknowledgements (SACKs) are a known common vector of exploitation.
 ## Duplicate select acknowledgements (DSACKs) are an extension of SACK.
-## Forward acknowledgements (FACKs) are a legacy option that will (eventually) be deprecated.
 ## Disabling can cause severe connectivity issues on networks with high latency or packet loss.
 ## Enabling on stable high-bandwidth networks can lead to reduced efficiency of TCP connections.
 ##
@@ -315,7 +314,6 @@ net.ipv6.conf.default.accept_ra=0
 ##
 #net.ipv4.tcp_sack=0
 #net.ipv4.tcp_dsack=0
-#net.ipv4.tcp_fack=0
 
 ## Disable TCP timestamps to limit device fingerprinting via system time.
 ##


### PR DESCRIPTION
As per https://github.com/Kicksecure/security-misc/pull/231#issuecomment-2233106253.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
