### PR TITLE
Disable the usage of `ptrace()` by all processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ space, user space, core dumps, and swap space.
 
 - Disable asynchronous I/O (when using Linux kernel version >= 6.6).
 
-- Restrict usage of `ptrace()` to only processes with `CAP_SYS_PTRACE` as it
-  enables programs to inspect and modify other active processes. Provide the
-  option to entirely disable the use of `ptrace()` for all processes.
+- Disable the usage of `ptrace()` by all processes as it enables programs to
+  inspect and modify other active processes.
 
 - Prevent hardlink and symlink TOCTOU races in world-writable directories.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ space, user space, core dumps, and swap space.
 
 - Disable asynchronous I/O (when using Linux kernel version >= 6.6).
 
-- Disable the usage of `ptrace()` by all processes as it enables programs to
-  inspect and modify other active processes.
+- Restrict usage of `ptrace()` to only processes with `CAP_SYS_PTRACE` as it
+  enables programs to inspect and modify other active processes. Provide the
+  option to entirely disable the use of `ptrace()` for all processes.
 
 - Prevent hardlink and symlink TOCTOU races in world-writable directories.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -128,7 +128,7 @@ kernel.io_uring_disabled=2
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#sysctl-userspace
 
-## Restrict usage of the ptrace() system call to only processes with CAP_SYS_PTRACE.
+## Disable the usage of ptrace() system calls by all processes.
 ## Limit ptrace() as it enables programs to inspect and modify other active processes.
 ## Prevents native code debugging which some programs use as a method to detect tampering.
 ## May cause breakages in 'anti-cheat' software and programs running under Proton/WINE.
@@ -139,9 +139,7 @@ kernel.io_uring_disabled=2
 ## https://github.com/GrapheneOS/os-issue-tracker/issues/651#issuecomment-917599928
 ## https://github.com/netblue30/firejail/issues/2860
 ##
-## It is possible to harden further by disabling ptrace() for all users, see documentation.
-##
-kernel.yama.ptrace_scope=2
+kernel.yama.ptrace_scope=3
 
 ## Maximize bits of entropy for improved effectiveness of mmap ASLR.
 ## The maximum number of bits depends on CPU architecture (the ones shown below are for x86).

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -128,7 +128,7 @@ kernel.io_uring_disabled=2
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#sysctl-userspace
 
-## Disable the usage of ptrace() system calls by all processes.
+## Restrict usage of the ptrace() system call to only processes with CAP_SYS_PTRACE.
 ## Limit ptrace() as it enables programs to inspect and modify other active processes.
 ## Prevents native code debugging which some programs use as a method to detect tampering.
 ## May cause breakages in 'anti-cheat' software and programs running under Proton/WINE.
@@ -139,7 +139,9 @@ kernel.io_uring_disabled=2
 ## https://github.com/GrapheneOS/os-issue-tracker/issues/651#issuecomment-917599928
 ## https://github.com/netblue30/firejail/issues/2860
 ##
-kernel.yama.ptrace_scope=3
+## It is possible to harden further by disabling ptrace() for all users, see documentation.
+##
+kernel.yama.ptrace_scope=2
 
 ## Maximize bits of entropy for improved effectiveness of mmap ASLR.
 ## The maximum number of bits depends on CPU architecture (the ones shown below are for x86).

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -140,6 +140,7 @@ kernel.io_uring_disabled=2
 ## https://github.com/netblue30/firejail/issues/2860
 ##
 ## It is possible to harden further by disabling ptrace() for all users, see documentation.
+## https://github.com/Kicksecure/security-misc/pull/242
 ##
 kernel.yama.ptrace_scope=2
 


### PR DESCRIPTION
Upgrade existing `sysctl` to now disable `ptrace()` usage by all processes.

Previously it was restricted to users with `CAP_SYS_PTRACE`.

It is unlikely that this would cause significantly more software breakages than the previous setting.

Needs to be thoroughly tested before being upgraded.

## Changes

`kernel.yama.ptrace_scope=2`
to
`kernel.yama.ptrace_scope=3`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it