### PR TITLE
Restrict unprivileged user namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ space, user space, core dumps, and swap space.
 - Entirely disable the SysRq key so that the Secure Attention Key (SAK)
   can no longer be utilized. See [documentation](https://www.kicksecure.com/wiki/SysRq).
 
-- Provide the option to disable unprivileged user namespaces as they can lead to
-  substantial privilege escalation.
+- Restrict user namespaces to `CAP_SYS_ADMIN` as they can lead to substantial
+  privilege escalation.
 
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -91,14 +91,12 @@ kernel.sysrq=0
 ## Restrict user namespaces to users with CAP_SYS_ADMIN.
 ## User namespaces aim to improve sandboxing and accessibility for unprivileged users.
 ## Unprivileged user namespaces pose substantial privilege escalation risks.
-## Restricting is known to cause breakages across numerous software packages.
+## Restricting may lead to breakages in numerous software packages.
 ##
 ## https://madaidans-insecurities.github.io/linux.html#kernel
 ## https://github.com/a13xp0p0v/kernel-hardening-checker#questions-and-answers
 ##
-## Unprivileged user namespaces are currently enabled.
-##
-#kernel.unprivileged_userns_clone=0
+kernel.unprivileged_userns_clone=0
 
 ## Restricts kernel profiling to users with CAP_PERFMON.
 ## The performance events system should not be accessible by unprivileged users.


### PR DESCRIPTION
Enable `sysctl` to restrict user namespaces to users with `CAP_SYS_ADMIN`.

Likely not enabled in the past due to breakages across numerous software.

However, now that we are on Debian Bookworm (kernel 6.1.x) and years have passed since the introduction of this parameter, a lot of software has began accommodating this parameter.

FOSS in my experience works fine. A lot of proprietary software works but some will quite likely break.

For example, one difference appears to be that software that uses the system-wide Electron versions are all functional, whereas some of those that package their own version may not work.

Needs to be thoroughly tested before being enabled.

## Changes

`kernel.unprivileged_userns_clone=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it