### PR TITLE
Minor documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ modules from starting. This approach should not be considered comprehensive;
 rather, it is a form of badness enumeration. Any potential candidates for future
 disabling should first be blacklisted for a suitable amount of time.
 
+- Optional - Bluetooth: Disabled to reduce attack surface.
+
+- Optional - CPU MSRs: Disabled as can be abused to write to arbitrary memory.
+
 - File Systems: Disable uncommon and legacy file systems.
 
 - FireWire (IEEE 1394): Disabled as they are often vulnerable to DMA attacks.
@@ -207,20 +211,25 @@ disabling should first be blacklisted for a suitable amount of time.
 - GPS: Disable GPS-related modules such as those required for Global Navigation
   Satellite Systems (GNSS).
 
-- Not yet enabled: Intel Management Engine (ME): Provides some disabling of the interface between the
-  Intel ME and the OS. See discussion: https://github.com/Kicksecure/security-misc/issues/239
+- Optional - Intel Management Engine (ME): Provides some disabling of the interface
+  between the Intel ME and the OS. May lead to breakages in places such as security,
+  power management, display, and DRM. See discussion: https://github.com/Kicksecure/security-misc/issues/239
 
 - Intel Platform Monitoring Technology Telemetry (PMT): Disable some functionality
   of the Intel PMT components.
 
 - Network File Systems: Disable uncommon and legacy network file systems.
 
-- Network Protocols: A wide array of uncommon and legacy network protocols are disabled.
+- Network Protocols: A wide array of uncommon and legacy network protocols and drivers
+  are disabled.
 
 - Miscellaneous: Disable an assortment of other modules such as those required
   for amateur radio, floppy disks, and vivid.
 
 - Thunderbolt: Disabled as they are often vulnerable to DMA attacks.
+
+- Optional - USB Video Device Class: Disables the USB-based video streaming driver for
+  devices like some webcams and digital camcorders.
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ configuration file.
 - Force kernel panics on "oopses" to potentially indicate and thwart certain
   kernel exploitation attempts.
 
-- Provide option to modify machine check exception handler.
+- Provide the option to modify machine check exception handler.
 
-- Provide option to disable support for all x86 processes and syscalls to reduce
+- Provide the option to disable support for all x86 processes and syscalls to reduce
   attack surface (when using Linux kernel version >= 6.7).
 
 - Enable strict IOMMU translation to protect against DMA attacks and disable
@@ -147,7 +147,7 @@ configuration file.
 - Obtain more entropy at boot from RAM as the runtime memory allocator is
   being initialized.
 
-- Provide option to disable the entire IPv6 stack to reduce attack surface.
+- Provide the option to disable the entire IPv6 stack to reduce attack surface.
 
 Disallow sensitive kernel information leaks in the console during boot. See
 the `/etc/default/grub.d/41_quiet_boot.cfg` configuration file.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Various networking components of the TCP/IP stack are hardened for IPv4/6.
   from all interfaces to prevent IP spoofing.
 
 - Disable ICMP redirect acceptance and redirect sending messages to
-  prevent man-in-the-middle attacks and minimize information disclosure.
+  prevent man-in-the-middle attacks and minimize information disclosure. If
+  ICMP redirect messages are permitted, only do so from approved gateways.
 
 - Ignore ICMP echo requests to prevent clock fingerprinting and Smurf attacks.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ space, user space, core dumps, and swap space.
 
 - Randomize the addresses (ASLR) for mmap base, stack, VDSO pages, and heap.
 
-- Disable asynchronous I/O (when using Linux kernel version >= 6.6).
+- Provide the option to disable asynchronous I/O as `io_uring` has been the source
+  of numerous kernel exploits (when using Linux kernel version >= 6.6).
 
 - Restrict usage of `ptrace()` to only processes with `CAP_SYS_PTRACE` as it
   enables programs to inspect and modify other active processes. Provide the

--- a/debian/security-misc.maintscript
+++ b/debian/security-misc.maintscript
@@ -47,7 +47,7 @@ rm_conffile /etc/sysctl.d/30_security-misc.conf
 rm_conffile /etc/sysctl.d/30_silent-kernel-printk.conf
 rm_conffile /etc/sysctl.d/30_security-misc_kexec-disable.conf
 
-## moved to etc/permission-hardener.d
+## moved to /etc/permission-hardener.d
 rm_conffile /etc/permission-hardening.d/25_default_passwd.conf
 rm_conffile /etc/permission-hardening.d/25_default_sudo.conf
 rm_conffile /etc/permission-hardening.d/25_default_whitelist_bubblewrap.conf

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -195,6 +195,6 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX extra_latent_entropy"
 ## https://www.kernel.org/doc/html/latest/networking/ipv6.html
 ## https://wiki.archlinux.org/title/IPv6#Disable_IPv6
 ##
-## Enabling makes redundant many network hardening sysctl's in usr/lib/sysctl.d/990-security-misc.conf.
+## Enabling makes redundant many network hardening sysctl's in /usr/lib/sysctl.d/990-security-misc.conf.
 ##
 #ipv6.disable=1

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -5,7 +5,7 @@ kpkg="linux-image-$(dpkg --print-architecture)" || true
 kver="$(dpkg-query --show --showformat='${Version}' "$kpkg")" 2>/dev/null || true
 #echo "## kver: $kver"
 
-## This configuration file is split into 3 sections:
+## This configuration file is split into 4 sections:
 ## 1. Kernel Space
 ## 2. Direct Memory Access
 ## 3. Entropy

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -14,6 +14,7 @@
 ## https://en.wikipedia.org/wiki/Bluetooth#History_of_security_concerns
 ##
 ## Now replaced by a privacy and security preserving default Bluetooth configuration for better usability.
+## https://github.com/Kicksecure/security-misc/pull/145
 ##
 #install bluetooth /usr/bin/disabled-bluetooth-by-security-misc
 #install bluetooth_6lowpan  /usr/bin/disabled-bluetooth-by-security-misc
@@ -43,7 +44,7 @@
 
 ## File Systems:
 ## Disable uncommon file systems to reduce attack surface.
-## HFS and HFS+ are legacy Apple file systems that may be required depending on the EFI partition format.
+## HFS/HFS+ are legacy Apple file systems that may be required depending on the EFI partition format.
 ##
 install cramfs /usr/bin/disabled-filesys-by-security-misc
 install freevxfs /usr/bin/disabled-filesys-by-security-misc
@@ -82,13 +83,14 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 
 ## Intel Management Engine (ME):
 ## Partially disable the Intel ME interface with the OS.
-## ME functionality has increasing become more intertwined with basic system operation.
-## Disabling may lead to breakages places such as security, power management, display, and DRM.
+## ME functionality has increasing become more intertwined with basic Intel system operation.
+## Disabling may lead to breakages in places such as security, power management, display, and DRM.
 ##
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 ## https://en.wikipedia.org/wiki/Intel_Management_Engine#Security_vulnerabilities
 ## https://www.kicksecure.com/wiki/Out-of-band_Management_Technology#Intel_ME_Disabling_Disadvantages
 ## https://github.com/Kicksecure/security-misc/pull/236#issuecomment-2229092813
+## https://github.com/Kicksecure/security-misc/issues/239
 ##
 #install mei /usr/bin/disabled-intelme-by-security-misc
 #install mei-gsc /usr/bin/disabled-intelme-by-security-misc
@@ -219,11 +221,6 @@ install hamradio /usr/bin/disabled-miscellaneous-by-security-misc
 ##
 install floppy /usr/bin/disabled-miscellaneous-by-security-misc
 ##
-## USB Video Device Class:
-## Disables USB-based video streaming driver for devices like webcams and digital camcorders.
-##
-#install uvcvideo /usr/bin/disabled-miscellaneous-by-security-misc
-##
 ## Vivid:
 ## Disables the vivid kernel module since it has been the cause of multiple vulnerabilities.
 ##
@@ -241,3 +238,8 @@ install vivid /usr/bin/disabled-miscellaneous-by-security-misc
 install intel-wmi-thunderbolt /usr/bin/disabled-thunderbolt-by-security-misc
 install thunderbolt /usr/bin/disabled-thunderbolt-by-security-misc
 install thunderbolt_net /usr/bin/disabled-thunderbolt-by-security-misc
+
+## USB Video Device Class:
+## Disables the USB-based video streaming driver for devices like some webcams and digital camcorders.
+##
+#install uvcvideo /usr/bin/disabled-miscellaneous-by-security-misc

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -117,12 +117,18 @@ kernel.perf_event_paranoid=3
 kernel.randomize_va_space=2
 
 ## Disable asynchronous I/O for all processes.
+## Leading cause of numerous kernel exploits.
+## Disabling will reduce the read/write performance of storage devices.
 ##
+## https://en.wikipedia.org/wiki/Io_uring#Security
+## https://lwn.net/Articles/902466/
 ## https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html
+## https://github.com/moby/moby/pull/46762
+## https://forums.whonix.org/t/io-uring-security-vulnerabilties/16890
 ##
 ## Applicable when using Linux kernel >= 6.6 (retained here for future-proofing and completeness).
 ##
-kernel.io_uring_disabled=2
+#kernel.io_uring_disabled=2
 
 ## 2. User Space:
 ##


### PR DESCRIPTION
Several small documentation changes, fixes, and inclusions.

## Changes

Due to the recent documentation upgrades providing a much clear explanations of various settings, should comment out `kernel.io_uring_disabled=2` since it is not applicable till Linux kernel version 6.6.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it