### PR TITLE
Update `/etc/modprobe.d/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ disabling should first be blacklisted for a suitable amount of time.
   are disabled.
 
 - Miscellaneous: Disable an assortment of other modules such as those required
-  for amateur radio, floppy disks, and vivid.
+  for amateur radio, floppy disks, and vivid. Also disable legacy drivers that
+  have been entirely replaced by newer drivers.
 
 - Thunderbolt: Disabled as they are often vulnerable to DMA attacks.
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,6 @@ modules from automatically starting.
 
 - CD-ROM/DVD: Blacklist modules required for CD-ROM/DVD devices.
 
-- Framebuffer Drivers: Blacklisted as they are well-known to be buggy, cause
-  kernel panics, and are generally only used by legacy devices.
-
 - Miscellaneous: Blacklist an assortment of other modules to prevent them from
   automatically loading.
 
@@ -209,6 +206,9 @@ disabling should first be blacklisted for a suitable amount of time.
 - File Systems: Disable uncommon and legacy file systems.
 
 - FireWire (IEEE 1394): Disabled as they are often vulnerable to DMA attacks.
+
+- Framebuffer Drivers: Disabled as they are well-known to be buggy, cause
+  kernel panics, and are generally only used by legacy devices.
 
 - GPS: Disable GPS-related modules such as those required for Global Navigation
   Satellite Systems (GNSS).

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ disabling should first be blacklisted for a suitable amount of time.
   Satellite Systems (GNSS).
 
 - Optional - Intel Management Engine (ME): Provides some disabling of the interface
-  between the Intel ME and the OS. May lead to breakages in places such as security,
-  power management, display, and DRM. See discussion: https://github.com/Kicksecure/security-misc/issues/239
+  between the Intel ME and the OS. May lead to breakages in places such as firmware
+  updates, security, power management, display, and DRM. See discussion: https://github.com/Kicksecure/security-misc/issues/239
 
-- Intel Platform Monitoring Technology Telemetry (PMT): Disable some functionality
+- Intel Platform Monitoring Technology (PMT) Telemetry: Disable some functionality
   of the Intel PMT components.
 
 - Network File Systems: Disable uncommon and legacy network file systems.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ disabling should first be blacklisted for a suitable amount of time.
 
 - FireWire (IEEE 1394): Disabled as they are often vulnerable to DMA attacks.
 
-- Framebuffer Drivers: Disabled as they are well-known to be buggy, cause
+- Framebuffer (fbdev): Disabled as drivers are well-known to be buggy, cause
   kernel panics, and are generally only used by legacy devices.
 
 - GPS: Disable GPS-related modules such as those required for Global Navigation

--- a/etc/modprobe.d/30_security-misc_blacklist.conf
+++ b/etc/modprobe.d/30_security-misc_blacklist.conf
@@ -26,14 +26,10 @@ blacklist sr_mod
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
 ##
-blacklist ath_pci
 blacklist amd76x_edac
-blacklist asus_acpi
-blacklist bcm43xx
+blacklist ath_pci
 blacklist evbug
-blacklist de4x5
 blacklist pcspkr
-blacklist prism54
 blacklist snd_aw2
 blacklist snd_intel8x0m
 blacklist snd_pcsp

--- a/etc/modprobe.d/30_security-misc_blacklist.conf
+++ b/etc/modprobe.d/30_security-misc_blacklist.conf
@@ -23,6 +23,26 @@ blacklist sr_mod
 
 ## Miscellaneous:
 ##
+## GrapheneOS:
+## Partial selection of their infrastructure blacklist.
+## Duplicate and already disabled modules have been omitted.
+##
+## https://github.com/GrapheneOS/infrastructure/blob/main/modprobe.d/local.conf
+##
+#blacklist cfg80211
+#blacklist intel_agp
+#blacklist ip_tables
+blacklist joydev
+#blacklist mousedev
+#blacklist psmouse
+blacklist snd_intel8x0
+#blacklist tls
+#blacklist virtio_balloon
+#blacklist virtio_console
+##
+## Ubuntu:
+## Already disabled modules have been omitted.
+##
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-ath_pci.conf?h=ubuntu/disco
 ##

--- a/etc/modprobe.d/30_security-misc_blacklist.conf
+++ b/etc/modprobe.d/30_security-misc_blacklist.conf
@@ -21,39 +21,6 @@ blacklist sr_mod
 #install cdrom /usr/bin/disabled-cdrom-by-security-misc
 #install sr_mod /usr/bin/disabled-cdrom-by-security-misc
 
-## Framebuffer Drivers:
-##
-## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
-##
-blacklist aty128fb
-blacklist atyfb
-blacklist cirrusfb
-blacklist cyber2000fb
-blacklist cyblafb
-blacklist gx1fb
-blacklist hgafb
-blacklist i810fb
-blacklist intelfb
-blacklist kyrofb
-blacklist lxfb
-blacklist matroxfb_bases
-blacklist neofb
-blacklist nvidiafb
-blacklist pm2fb
-blacklist radeonfb
-blacklist rivafb
-blacklist s1d13xxxfb
-blacklist savagefb
-blacklist sisfb
-blacklist sstfb
-blacklist tdfxfb
-blacklist tridentfb
-blacklist vesafb
-blacklist vfb
-blacklist viafb
-blacklist vt8623fb
-blacklist udlfb
-
 ## Miscellaneous:
 ##
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -70,10 +70,12 @@ install raw1394 /usr/bin/disabled-firewire-by-security-misc
 install sbp2 /usr/bin/disabled-firewire-by-security-misc
 install video1394 /usr/bin/disabled-firewire-by-security-misc
 
-## Framebuffer Drivers:
-## Known to be buggy, cause kernel panics, and are generally only used by legacy devices.
+## Framebuffer (fbdev):
+## Video drivers are known to be buggy, cause kernel panics, and are generally only used by legacy devices.
 ## These were all previously blacklisted.
 ##
+## https://docs.kernel.org/fb/index.html
+## https://en.wikipedia.org/wiki/Linux_framebuffer
 ## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
 ##
 install aty128fb /usr/bin/disabled-framebuffer-by-security-misc

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -256,6 +256,17 @@ install hamradio /usr/bin/disabled-miscellaneous-by-security-misc
 ##
 install floppy /usr/bin/disabled-miscellaneous-by-security-misc
 ##
+## Replaced:
+## These legacy drivers have all been entirely replaced and superseded by newer drivers.
+## These were all previously blacklisted.
+##
+## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist.conf?h=ubuntu/disco
+##
+install asus_acpi /usr/bin/disabled-miscellaneous-by-security-misc
+install bcm43xx /usr/bin/disabled-miscellaneous-by-security-misc
+install de4x5 /usr/bin/disabled-miscellaneous-by-security-misc
+install prism54 /usr/bin/disabled-miscellaneous-by-security-misc
+##
 ## Vivid:
 ## Disables the vivid kernel module since it has been the cause of multiple vulnerabilities.
 ##

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -70,6 +70,41 @@ install raw1394 /usr/bin/disabled-firewire-by-security-misc
 install sbp2 /usr/bin/disabled-firewire-by-security-misc
 install video1394 /usr/bin/disabled-firewire-by-security-misc
 
+## Framebuffer Drivers:
+## Known to be buggy, cause kernel panics, and are generally only used by legacy devices.
+## These were all previously blacklisted.
+##
+## https://git.launchpad.net/ubuntu/+source/kmod/tree/debian/modprobe.d/blacklist-framebuffer.conf?h=ubuntu/disco
+##
+install aty128fb /usr/bin/disabled-framebuffer-by-security-misc
+install atyfb /usr/bin/disabled-framebuffer-by-security-misc
+install cirrusfb /usr/bin/disabled-framebuffer-by-security-misc
+install cyber2000fb /usr/bin/disabled-framebuffer-by-security-misc
+install cyblafb /usr/bin/disabled-framebuffer-by-security-misc
+install gx1fb /usr/bin/disabled-framebuffer-by-security-misc
+install hgafb /usr/bin/disabled-framebuffer-by-security-misc
+install i810fb /usr/bin/disabled-framebuffer-by-security-misc
+install intelfb /usr/bin/disabled-framebuffer-by-security-misc
+install kyrofb /usr/bin/disabled-framebuffer-by-security-misc
+install lxfb /usr/bin/disabled-framebuffer-by-security-misc
+install matroxfb_bases /usr/bin/disabled-framebuffer-by-security-misc
+install neofb /usr/bin/disabled-framebuffer-by-security-misc
+install nvidiafb /usr/bin/disabled-framebuffer-by-security-misc
+install pm2fb /usr/bin/disabled-framebuffer-by-security-misc
+install radeonfb /usr/bin/disabled-framebuffer-by-security-misc
+install rivafb /usr/bin/disabled-framebuffer-by-security-misc
+install s1d13xxxfb /usr/bin/disabled-framebuffer-by-security-misc
+install savagefb /usr/bin/disabled-framebuffer-by-security-misc
+install sisfb /usr/bin/disabled-framebuffer-by-security-misc
+install sstfb /usr/bin/disabled-framebuffer-by-security-misc
+install tdfxfb /usr/bin/disabled-framebuffer-by-security-misc
+install tridentfb /usr/bin/disabled-framebuffer-by-security-misc
+install vesafb /usr/bin/disabled-framebuffer-by-security-misc
+install vfb /usr/bin/disabled-framebuffer-by-security-misc
+install viafb /usr/bin/disabled-framebuffer-by-security-misc
+install vt8623fb /usr/bin/disabled-framebuffer-by-security-misc
+install udlfb /usr/bin/disabled-framebuffer-by-security-misc
+
 ## Global Positioning Systems (GPS):
 ## Disable GPS-related modules like GNSS (Global Navigation Satellite System).
 ##

--- a/etc/modprobe.d/30_security-misc_disable.conf
+++ b/etc/modprobe.d/30_security-misc_disable.conf
@@ -119,7 +119,8 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 ## Intel Management Engine (ME):
 ## Partially disable the Intel ME interface with the OS.
 ## ME functionality has increasing become more intertwined with basic Intel system operation.
-## Disabling may lead to breakages in places such as security, power management, display, and DRM.
+## Disabling may lead to breakages in numerous places without clear debugging/error messages.
+## May cause issues with firmware updates, security, power management, display, and DRM.
 ##
 ## https://www.kernel.org/doc/html/latest/driver-api/mei/mei.html
 ## https://en.wikipedia.org/wiki/Intel_Management_Engine#Security_vulnerabilities
@@ -140,7 +141,7 @@ install gnss-usb /usr/bin/disabled-gps-by-security-misc
 #install mei_wdt /usr/bin/disabled-intelme-by-security-misc
 #install microread_mei /usr/bin/disabled-intelme-by-security-misc
 
-## Intel Platform Monitoring Technology Telemetry (PMT):
+## Intel Platform Monitoring Technology (PMT) Telemetry:
 ## Disable some functionality of the Intel PMT components.
 ##
 ## https://github.com/intel/Intel-PMT

--- a/usr/bin/disabled-bluetooth-by-security-misc
+++ b/usr/bin/disabled-bluetooth-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This Bluetooth kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This Bluetooth kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-bluetooth-by-security-misc
+++ b/usr/bin/disabled-bluetooth-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This Bluetooth kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This Bluetooth kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-cdrom-by-security-misc
+++ b/usr/bin/disabled-cdrom-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This CD-ROM/DVD kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This CD-ROM/DVD kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-cdrom-by-security-misc
+++ b/usr/bin/disabled-cdrom-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This CD-ROM/DVD kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This CD-ROM/DVD kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-filesys-by-security-misc
+++ b/usr/bin/disabled-filesys-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-filesys-by-security-misc
+++ b/usr/bin/disabled-filesys-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-firewire-by-security-misc
+++ b/usr/bin/disabled-firewire-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This FireWire (IEEE 1394) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This FireWire (IEEE 1394) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-firewire-by-security-misc
+++ b/usr/bin/disabled-firewire-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This FireWire (IEEE 1394) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This FireWire (IEEE 1394) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-framebuffer-by-security-misc
+++ b/usr/bin/disabled-framebuffer-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This framebuffer driver kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This framebuffer driver kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-framebuffer-by-security-misc
+++ b/usr/bin/disabled-framebuffer-by-security-misc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Copyright (C) 2024 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+
+echo "$0: ERROR: This framebuffer driver kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+
+exit 1

--- a/usr/bin/disabled-framebuffer-by-security-misc
+++ b/usr/bin/disabled-framebuffer-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ALERT: This framebuffer kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
+echo "$0: ALERT: This framebuffer (fbdev) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-framebuffer-by-security-misc
+++ b/usr/bin/disabled-framebuffer-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2024 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This framebuffer driver kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This framebuffer kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-gps-by-security-misc
+++ b/usr/bin/disabled-gps-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This GPS (Global Positioning System) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This GPS (Global Positioning System) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-gps-by-security-misc
+++ b/usr/bin/disabled-gps-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This GPS (Global Positioning System) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This Global Positioning System (GPS) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-intelme-by-security-misc
+++ b/usr/bin/disabled-intelme-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This Intel Management Engine (ME) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This Intel Management Engine (ME) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-intelme-by-security-misc
+++ b/usr/bin/disabled-intelme-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This Intel Management Engine (ME) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This Intel Management Engine (ME) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-intelpmt-by-security-misc
+++ b/usr/bin/disabled-intelpmt-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This Intel Platform Monitoring Technology Telemetry (PMT) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This Intel Platform Monitoring Technology Telemetry (PMT) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-intelpmt-by-security-misc
+++ b/usr/bin/disabled-intelpmt-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2024 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This Intel Platform Monitoring Technology Telemetry (PMT) kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This Intel Platform Monitoring Technology (PMT) Telemetry kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-miscellaneous-by-security-misc
+++ b/usr/bin/disabled-miscellaneous-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-miscellaneous-by-security-misc
+++ b/usr/bin/disabled-miscellaneous-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-netfilesys-by-security-misc
+++ b/usr/bin/disabled-netfilesys-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This network file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This network file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-netfilesys-by-security-misc
+++ b/usr/bin/disabled-netfilesys-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This network file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This network file system kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-network-by-security-misc
+++ b/usr/bin/disabled-network-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This network protocol kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This network protocol kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-network-by-security-misc
+++ b/usr/bin/disabled-network-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This network protocol kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This network protocol kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-thunderbolt-by-security-misc
+++ b/usr/bin/disabled-thunderbolt-by-security-misc
@@ -5,6 +5,6 @@
 
 ## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
 
-echo "$0: ERROR: This Thunderbolt kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf | args: $@" >&2
+echo "$0: ERROR: This Thunderbolt kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
 
 exit 1

--- a/usr/bin/disabled-thunderbolt-by-security-misc
+++ b/usr/bin/disabled-thunderbolt-by-security-misc
@@ -3,8 +3,8 @@
 ## Copyright (C) 2019 - 2024 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
-## Alerts the user that a kernel module failed to load due to it being blacklisted by default.
+## Alerts user that a kernel module failed to load due to it being explicitly disabled by default.
 
-echo "$0: ERROR: This Thunderbolt kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf. | args: $@" >&2
+echo "$0: ALERT: This Thunderbolt kernel module is disabled by package security-misc by default. See the configuration file /etc/modprobe.d/30_security-misc_disable.conf for details. | args: $@" >&2
 
 exit 1


### PR DESCRIPTION
Move existing blacklisted framebuffer and some superseded drivers to the disabled list. 

This way we can start using `30_security-misc_blacklist.conf` as a testing/proving ground for potential future disabling.

https://forums.whonix.org/t/kernel-hardening-security-misc/7296/560

## Changes

Transfer some kernel modules to the disable list that have previously been blacklisted for over two years with seemingly no user complaints.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it