### PR TITLE
Provide the option to change the default CFI implementation in the future

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ configuration file.
 
 - Provide the option to modify machine check exception handler.
 
-- Provide the option to use kCFI as the default CFI implementation as it may be
-  slightly more resilient to attacks that can construct arbitrary executable
-  memory contents (when using Linux kernel version >= 6.5).
+- Provide the option to use kCFI as the default CFI implementation since it may be
+  slightly more resilient to attacks that are able to write arbitrary executables
+  in memory (when using Linux kernel version >= 6.2).
 
 - Provide the option to disable support for all x86 processes and syscalls to reduce
   attack surface (when using Linux kernel version >= 6.7).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ configuration file.
 
 - Provide the option to modify machine check exception handler.
 
+- Provide the option to use kCFI as the default CFI implementation as it may be
+  slightly more resilient to attacks that can construct arbitrary executable
+  memory contents (when using Linux kernel version >= 6.5).
+
 - Provide the option to disable support for all x86 processes and syscalls to reduce
   attack surface (when using Linux kernel version >= 6.7).
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -112,6 +112,25 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX loglevel=0"
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX quiet"
 
+## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.
+## As of Linux kernel 6.2, FineIBT has been the default implementation.
+## Intel-developed IBT (Indirect Branch Tracking) is only used if there support by the CPU.
+## kCFI is software-only while FineIBT is a hybrid software/hardware implementation.
+## FineIBT may result in performance benefits as it only performs checking at destinations.
+## FineIBT is weaker against attacks that can construct arbitrary executable memory contents.
+## Choice of this parameter is dependant on user threat model as there are pros/cons to both.
+##
+## https://docs.kernel.org/next/x86/shstk.html
+## https://lore.kernel.org/lkml/202210010918.4918F847C4@keescook/T/#u
+## https://lore.kernel.org/lkml/202210182217.486CBA50@keescook/T/
+## https://lore.kernel.org/lkml/202407150933.E1871BE@keescook/
+## https://isopenbsdsecu.re/mitigations/forward_edge_cfi/
+## https://source.android.com/docs/security/test/kcfi
+##
+## Applicable when using Linux kernel >= 6.5 (retained here for future-proofing and completeness).
+##
+#cfi=kcfi
+
 ## Disable support for x86 processes and syscalls.
 ## Unconditionally disables IA32 emulation to substantially reduce attack surface.
 ##

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -114,20 +114,25 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 
 ## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.
 ## As of Linux kernel 6.2, FineIBT has been the default implementation.
-## Intel-developed IBT (Indirect Branch Tracking) is only used if there support by the CPU.
+## The Intel-developed IBT (Indirect Branch Tracking) is only used if there support by the CPU.
 ## kCFI is software-only while FineIBT is a hybrid software/hardware implementation.
 ## FineIBT may result in performance benefits as it only performs checking at destinations.
-## FineIBT is weaker against attacks that can construct arbitrary executable memory contents.
-## Choice of this parameter is dependant on user threat model as there are pros/cons to both.
+## FineIBT is weaker against attacks that can write arbitrary executable in memory.
+## Upstream hardening has given users the ability to disable FineIBT based on requests.
+## Choice of CFI implementation is dependent on user threat model as there are pros/cons to both.
+## Do not modify this parameter if unsure of implications.
 ##
-## https://docs.kernel.org/next/x86/shstk.html
+## https://lore.kernel.org/all/20221027092842.699804264@infradead.org/
 ## https://lore.kernel.org/lkml/202210010918.4918F847C4@keescook/T/#u
 ## https://lore.kernel.org/lkml/202210182217.486CBA50@keescook/T/
 ## https://lore.kernel.org/lkml/202407150933.E1871BE@keescook/
 ## https://isopenbsdsecu.re/mitigations/forward_edge_cfi/
+## https://docs.kernel.org/next/x86/shstk.html
 ## https://source.android.com/docs/security/test/kcfi
+## https://lpc.events/event/16/contributions/1315/attachments/1067/2169/cfi.pdf
+## https://forums.whonix.org/t/kernel-hardening-security-misc/7296/561
 ##
-## Applicable when using Linux kernel >= 6.5 (retained here for future-proofing and completeness).
+## Applicable when using Linux kernel >= 6.2 (retained here for future-proofing and completeness).
 ##
 #cfi=kcfi
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -113,14 +113,14 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX quiet"
 
 ## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.
-## As of Linux kernel 6.2, FineIBT has been selected to be the default implementation.
-## The Intel-developed IBT (Indirect Branch Tracking) is only used if there is support by the CPU.
+## The default implementation is FIneIBT as of Linux kernel 6.2.
+## The Intel-developed IBT (Indirect Branch Tracking) is only used if supported by the CPU.
 ## kCFI is software-only while FineIBT is a hybrid software/hardware implementation.
 ## FineIBT may result in some performance benefits as it only performs checking at destinations.
-## FineIBT is considered weaker against attacks that can write arbitrary executable in memory.
-## Upstream hardening has given users the ability to disable FineIBT based on requests.
+## FineIBT is considered weaker against attacks that can write arbitrary executables into memory.
+## Upstream hardening work has provided users the ability to disable FineIBT based on requests.
 ## Choice of CFI implementation is highly dependent on user threat model as there are pros/cons to both.
-## Do not modify from default if unsure of implications.
+## Do not modify from the default setting if unsure of implications.
 ##
 ## https://lore.kernel.org/all/20221027092842.699804264@infradead.org/
 ## https://lore.kernel.org/lkml/202210010918.4918F847C4@keescook/T/#u
@@ -132,6 +132,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 ## https://lpc.events/event/16/contributions/1315/attachments/1067/2169/cfi.pdf
 ## https://forums.whonix.org/t/kernel-hardening-security-misc/7296/561
 ##
+## TODO: Debian 13 Trixie
 ## Applicable when using Linux kernel >= 6.2 (retained here for future-proofing and completeness).
 ##
 #cfi=kcfi

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -113,14 +113,14 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX debugfs=off"
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX quiet"
 
 ## Switch (back) to using kCFI as the default Control Flow Integrity (CFI) implementation.
-## As of Linux kernel 6.2, FineIBT has been the default implementation.
-## The Intel-developed IBT (Indirect Branch Tracking) is only used if there support by the CPU.
+## As of Linux kernel 6.2, FineIBT has been selected to be the default implementation.
+## The Intel-developed IBT (Indirect Branch Tracking) is only used if there is support by the CPU.
 ## kCFI is software-only while FineIBT is a hybrid software/hardware implementation.
-## FineIBT may result in performance benefits as it only performs checking at destinations.
-## FineIBT is weaker against attacks that can write arbitrary executable in memory.
+## FineIBT may result in some performance benefits as it only performs checking at destinations.
+## FineIBT is considered weaker against attacks that can write arbitrary executable in memory.
 ## Upstream hardening has given users the ability to disable FineIBT based on requests.
-## Choice of CFI implementation is dependent on user threat model as there are pros/cons to both.
-## Do not modify this parameter if unsure of implications.
+## Choice of CFI implementation is highly dependent on user threat model as there are pros/cons to both.
+## Do not modify from default if unsure of implications.
 ##
 ## https://lore.kernel.org/all/20221027092842.699804264@infradead.org/
 ## https://lore.kernel.org/lkml/202210010918.4918F847C4@keescook/T/#u


### PR DESCRIPTION
Add details on kernel parameter pertaining to security that should merit a review when rebasing to future Debian releases.

https://forums.whonix.org/t/kernel-hardening-security-misc/7296/561

## Changes

There are no changes to the actual functionality of the code.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it