### PR TITLE
Re-enable (default) `secure_redirects` for ICMP redirect messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ Various networking components of the TCP/IP stack are hardened for IPv4/6.
   from all interfaces to prevent IP spoofing.
 
 - Disable ICMP redirect acceptance and redirect sending messages to
-  prevent man-in-the-middle attacks and minimize information disclosure. If
-  ICMP redirect messages are permitted, only do so from approved gateways.
+  prevent man-in-the-middle attacks and minimize information disclosure.
 
 - Ignore ICMP echo requests to prevent clock fingerprinting and Smurf attacks.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Various networking components of the TCP/IP stack are hardened for IPv4/6.
   from all interfaces to prevent IP spoofing.
 
 - Disable ICMP redirect acceptance and redirect sending messages to
-  prevent man-in-the-middle attacks and minimize information disclosure.
+  prevent man-in-the-middle attacks and minimize information disclosure. If
+  ICMP redirect messages are permitted, only do so from approved gateways.
 
 - Ignore ICMP echo requests to prevent clock fingerprinting and Smurf attacks.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ Various networking components of the TCP/IP stack are hardened for IPv4/6.
 - Enable reverse path filtering (source validation) of packets received
   from all interfaces to prevent IP spoofing.
 
-- Disable ICMP redirect acceptance and redirect sending messages to
-  prevent man-in-the-middle attacks and minimize information disclosure. If
-  ICMP redirect messages are permitted, only do so from approved gateways.
+- Disable ICMP redirect acceptance and redirect sending messages to prevent
+  man-in-the-middle attacks and minimize information disclosure.
 
 - Ignore ICMP echo requests to prevent clock fingerprinting and Smurf attacks.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -260,6 +260,9 @@ net.ipv4.conf.default.rp_filter=1
 ## Disable ICMP redirect acceptance and redirect sending messages.
 ## Prevents man-in-the-middle attacks and minimizes information disclosure.
 ##
+## https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-disable-source-routing#sect-Security_Guide-Server_Security-Disable-Source-Routing
+## https://www.frozentux.net/ipsysctl-tutorial/chunkyhtml/theconfvariables.html
+## https://www.debian.org/doc/manuals/securing-debian-manual/network-secure.en.html
 ## https://askubuntu.com/questions/118273/what-are-icmp-redirects-and-should-they-be-blocked
 ##
 net.ipv4.conf.all.accept_redirects=0
@@ -268,12 +271,6 @@ net.ipv4.conf.all.send_redirects=0
 net.ipv4.conf.default.send_redirects=0
 net.ipv6.conf.all.accept_redirects=0
 net.ipv6.conf.default.accept_redirects=0
-
-## Accept ICMP redirect messages only for approved gateways.
-## If ICMP redirect messages are permitted, only useful if managing a default gateway list.
-##
-net.ipv4.conf.all.secure_redirects=0
-net.ipv4.conf.default.secure_redirects=0
 
 ## Ignore ICMP echo requests.
 ## Prevents clock fingerprinting through ICMP timestamps and Smurf attacks.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -272,6 +272,12 @@ net.ipv4.conf.default.send_redirects=0
 net.ipv6.conf.all.accept_redirects=0
 net.ipv6.conf.default.accept_redirects=0
 
+## Accept ICMP redirect messages only for approved gateways.
+## If ICMP redirect messages are permitted, only useful if managing a default gateway list.
+##
+net.ipv4.conf.all.secure_redirects=1
+net.ipv4.conf.default.secure_redirects=1
+
 ## Ignore ICMP echo requests.
 ## Prevents clock fingerprinting through ICMP timestamps and Smurf attacks.
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -259,11 +259,14 @@ net.ipv4.conf.default.rp_filter=1
 
 ## Disable ICMP redirect acceptance and redirect sending messages.
 ## Prevents man-in-the-middle attacks and minimizes information disclosure.
+## If ICMP redirects are permitted, accept messages only through approved gateways (kernel default).
+## Approving gateways requires the managing of a default gateway list.
 ##
 ## https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-disable-source-routing#sect-Security_Guide-Server_Security-Disable-Source-Routing
 ## https://www.frozentux.net/ipsysctl-tutorial/chunkyhtml/theconfvariables.html
 ## https://www.debian.org/doc/manuals/securing-debian-manual/network-secure.en.html
 ## https://askubuntu.com/questions/118273/what-are-icmp-redirects-and-should-they-be-blocked
+## https://github.com/Kicksecure/security-misc/pull/248
 ##
 net.ipv4.conf.all.accept_redirects=0
 net.ipv4.conf.default.accept_redirects=0
@@ -271,14 +274,8 @@ net.ipv4.conf.all.send_redirects=0
 net.ipv4.conf.default.send_redirects=0
 net.ipv6.conf.all.accept_redirects=0
 net.ipv6.conf.default.accept_redirects=0
-
-## Accept ICMP redirect messages only for approved gateways.
-## If ICMP redirect messages are permitted, only useful if managing a default gateway list.
-##
-## https://github.com/Kicksecure/security-misc/pull/248
-##
-net.ipv4.conf.all.secure_redirects=1
-net.ipv4.conf.default.secure_redirects=1
+#net.ipv4.conf.all.secure_redirects=1
+#net.ipv4.conf.default.secure_redirects=1
 
 ## Ignore ICMP echo requests.
 ## Prevents clock fingerprinting through ICMP timestamps and Smurf attacks.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -275,6 +275,8 @@ net.ipv6.conf.default.accept_redirects=0
 ## Accept ICMP redirect messages only for approved gateways.
 ## If ICMP redirect messages are permitted, only useful if managing a default gateway list.
 ##
+## https://github.com/Kicksecure/security-misc/pull/248
+##
 net.ipv4.conf.all.secure_redirects=1
 net.ipv4.conf.default.secure_redirects=1
 


### PR DESCRIPTION
Previously going back even further than  [4 years](https://github.com/Kicksecure/security-misc/blob/6a4c493213929b354a3c8d2acf2325473ae63cfd/etc/sysctl.d/30_security-misc.conf) we have actually not enabled secure redirects for ICMP redirect messages over IPv4.

This error is also in Madaidan's [guide](https://madaidans-insecurities.github.io/guides/linux-hardening.html#sysctl-network).

However, this mistake has not resulted in any breakages since we do not accept ICMP redirects by default:
```
net.ipv4.conf.*.accept_redirects=0
net.ipv4.conf.*.send_redirects=0
net.ipv6.conf.*.accept_redirects=0
```

If these were to be commented-out and restored back to `=1`'s, we would actually accept ICMP redirects for ALL gateways which is wrong!

See:
https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-disable-source-routing#sect-Security_Guide-Server_Security-Disable-Source-Routing
https://www.frozentux.net/ipsysctl-tutorial/chunkyhtml/theconfvariables.html
https://www.debian.org/doc/manuals/securing-debian-manual/network-secure.en.html
https://askubuntu.com/questions/118273/what-are-icmp-redirects-and-should-they-be-blocked

## Changes

`net.ipv4.conf.*.secure_redirects=0`
to
`net.ipv4.conf.*.secure_redirects=1` 

But `net.ipv4.conf.*.secure_redirects=1` is the default and so we should actually just remove the incorrect `systcl` as they are redundant.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it