### PR TITLE
Disallow registering interpreters for miscellaneous binary formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ space, user space, core dumps, and swap space.
 
 - Increase the maximum number of memory map areas a process is able to utilize.
 
-- Disallow registering interpreters for various (miscellaneous) binary formats based
-  on a magic number or their file extension to prevent unintended code execution.
+- Provide the option to disallow registering interpreters for various (miscellaneous)
+  binary formats based on a magic number or their file extension to prevent
+  unintended code execution.
 
 - Disable core dump files and prevent their creation. If core dump files are
   enabled, they will be named based on `core.PID` instead of the default `core`.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ space, user space, core dumps, and swap space.
 
 - Increase the maximum number of memory map areas a process is able to utilize.
 
-- Provide the option to disallow registering interpreters for various (miscellaneous)
-  binary formats based on a magic number or their file extension to prevent
-  unintended code execution.
+- Disallow registering interpreters for various (miscellaneous) binary formats based
+  on a magic number or their file extension to prevent unintended code execution.
 
 - Disable core dump files and prevent their creation. If core dump files are
   enabled, they will be named based on `core.PID` instead of the default `core`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ space, user space, core dumps, and swap space.
 
 - Increase the maximum number of memory map areas a process is able to utilize.
 
+- Disallow registering interpreters for various (miscellaneous) binary formats based
+  on a magic number or their file extension to prevent unintended code execution.
+
 - Disable core dump files and prevent their creation. If core dump files are
   enabled, they will be named based on `core.PID` instead of the default `core`.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -195,8 +195,8 @@ vm.max_map_count=1048576
 
 ## Disable the miscellaneous binary format virtual file system to prevent unintended code execution.
 ## Prevents registering interpreters for various binary formats based on a magic number or their file extension.
-## If arbitrary executable file formats are recognised, they will be passed to relevant user space applications.
-## These interpreters will run with root permissions when a setuid binary is owned by root.
+## Otherwise arbitrary executables with recognized file formats will be passed to relevant user space applications.
+## These interpreters will the run with root permissions when a setuid binary is owned by root.
 ## Can stop maliciously crafted files with specific file extensions from automatically executing.
 ## Breaks many scripts that do not have appropriate shebang interpreter directives (#!/bin/...).
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -206,11 +206,8 @@ vm.max_map_count=1048576
 ## https://en.wikipedia.org/wiki/Binfmt_misc
 ## https://security.stackexchange.com/questions/271786/does-allowing-binfmt-misc-significantly-increase-the-attack-surface-for-unprivil
 ## https://unix.stackexchange.com/questions/439569/what-kinds-of-executable-formats-do-the-files-under-proc-sys-fs-binfmt-misc-al
-## https://github.com/Kicksecure/security-misc/pull/249
 ##
-## The default kernel setting will be utilized until provided sufficient evidence to modify.
-##
-#fs.binfmt_misc.status=0
+fs.binfmt_misc.status=0
 
 ## 3. Core Dumps:
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -196,7 +196,7 @@ vm.max_map_count=1048576
 ## Disable the miscellaneous binary format virtual file system to prevent unintended code execution.
 ## Prevents registering interpreters for various binary formats based on a magic number or their file extension.
 ## Otherwise arbitrary executables with recognized file formats will be passed to relevant user space applications.
-## These interpreters will thn run with root permissions when a setuid binary is owned by root.
+## These interpreters will then run with root permissions when a setuid binary is owned by root.
 ## Can stop maliciously crafted files with specific file extensions from automatically executing.
 ## Breaks many scripts that do not have appropriate shebang interpreter directives (#!/bin/...).
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -206,6 +206,10 @@ vm.max_map_count=1048576
 ## https://en.wikipedia.org/wiki/Binfmt_misc
 ## https://security.stackexchange.com/questions/271786/does-allowing-binfmt-misc-significantly-increase-the-attack-surface-for-unprivil
 ## https://unix.stackexchange.com/questions/439569/what-kinds-of-executable-formats-do-the-files-under-proc-sys-fs-binfmt-misc-al
+## https://github.com/Kicksecure/security-misc/pull/249
+##
+## KSPP=yes
+## KSPP does not set CONFIG_BINFMT_MISC.
 ##
 fs.binfmt_misc.status=0
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -193,6 +193,22 @@ fs.protected_regular=2
 ##
 vm.max_map_count=1048576
 
+## Disable the miscellaneous binary format virtual file system to prevent unintended code execution.
+## Prevents registering interpreters for various binary formats based on a magic number or their file extension.
+## If arbitrary executable file formats are recognised, they will be passed to relevant user space applications.
+## These interpreters will run with root permissions when a setuid binary is owned by root.
+## Can stop maliciously crafted files with specific file extensions from automatically executing.
+## Breaks many scripts that do not have appropriate shebang interpreter directives (#!/bin/...).
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+## https://salsa.debian.org/debian/binfmt-support
+## https://access.redhat.com/solutions/1985633
+## https://en.wikipedia.org/wiki/Binfmt_misc
+## https://security.stackexchange.com/questions/271786/does-allowing-binfmt-misc-significantly-increase-the-attack-surface-for-unprivil
+## https://unix.stackexchange.com/questions/439569/what-kinds-of-executable-formats-do-the-files-under-proc-sys-fs-binfmt-misc-al
+##
+fs.binfmt_misc.status=0
+
 ## 3. Core Dumps:
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#core-dumps

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -196,7 +196,7 @@ vm.max_map_count=1048576
 ## Disable the miscellaneous binary format virtual file system to prevent unintended code execution.
 ## Prevents registering interpreters for various binary formats based on a magic number or their file extension.
 ## Otherwise arbitrary executables with recognized file formats will be passed to relevant user space applications.
-## These interpreters will the run with root permissions when a setuid binary is owned by root.
+## These interpreters will thn run with root permissions when a setuid binary is owned by root.
 ## Can stop maliciously crafted files with specific file extensions from automatically executing.
 ## Breaks many scripts that do not have appropriate shebang interpreter directives (#!/bin/...).
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -206,8 +206,11 @@ vm.max_map_count=1048576
 ## https://en.wikipedia.org/wiki/Binfmt_misc
 ## https://security.stackexchange.com/questions/271786/does-allowing-binfmt-misc-significantly-increase-the-attack-surface-for-unprivil
 ## https://unix.stackexchange.com/questions/439569/what-kinds-of-executable-formats-do-the-files-under-proc-sys-fs-binfmt-misc-al
+## https://github.com/Kicksecure/security-misc/pull/249
 ##
-fs.binfmt_misc.status=0
+## The default kernel setting will be utilized until provided sufficient evidence to modify.
+##
+#fs.binfmt_misc.status=0
 
 ## 3. Core Dumps:
 ##


### PR DESCRIPTION
Disallow registering interpreters for various (miscellaneous) binary formats based on a magic number or their file extension to prevent unintended code execution.

Breaks many scripts that do not have appropriate shebang interpreter directives (#!/bin/...).

## Changes

Set `sysctl fs.binfmt_misc.status=0`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it