### PR TITLE
Add details on "oopes" and kernel panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ space, user space, core dumps, and swap space.
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 
 - Force the kernel to panic on "oopses" that can potentially indicate and thwart
-  certain kernel exploitation attempts.
+  certain kernel exploitation attempts. Provide the option to reboot immediately
+  on a kernel panic.
 
 - Randomize the addresses (ASLR) for mmap base, stack, VDSO pages, and heap.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ space, user space, core dumps, and swap space.
 
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 
+- Force the kernel to panic on "oopses" that can potentially indicate and thwart
+  certain kernel exploitation attempts.
+
 - Randomize the addresses (ASLR) for mmap base, stack, VDSO pages, and heap.
 
 - Disable asynchronous I/O as `io_uring` has been the source

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -109,6 +109,17 @@ kernel.sysrq=0
 ##
 kernel.perf_event_paranoid=3
 
+## Force the kernel to panic on "oopses".
+## Can sometimes potentially indicate and thwart certain kernel exploitation attempts.
+## Also cause panics on machine check exceptions.
+## Panics may be due to false-positives such as bad drivers.
+##
+## https://forums.whonix.org/t/set-oops-panic-kernel-parameter-or-kernel-panic-on-oops-1-sysctl-for-better-security/7713
+##
+## See /usr/libexec/security-misc/panic-on-oops for implementation.
+##
+#kernel.panic_on_oops=1
+
 ## Enable ASLR for mmap base, stack, VDSO pages, and heap.
 ## Heap randomization can lead to breakages with legacy applications.
 ##

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -119,6 +119,7 @@ kernel.perf_event_paranoid=3
 ## See /usr/libexec/security-misc/panic-on-oops for implementation.
 ##
 #kernel.panic_on_oops=1
+#kernel.panic=-1
 
 ## Enable ASLR for mmap base, stack, VDSO pages, and heap.
 ## Heap randomization can lead to breakages with legacy applications.

--- a/usr/libexec/security-misc/panic-on-oops
+++ b/usr/libexec/security-misc/panic-on-oops
@@ -16,3 +16,4 @@ fi
 ## from continuing to run a flawed processes. Many kernel exploits
 ## will also cause an oops which this will make the kernel kill.
 sysctl kernel.panic_on_oops=1
+#sysctl kernel.panic=-1


### PR DESCRIPTION
Adds documentation on `sysctl kernel.panic_on_oops=1`.

Provides the option to immediately reboot on kernel panics.

## Changes

There are no changes to the actual functionality of the code.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it