### PR TITLE
Mitigate tar storing usernames and groups

### DIFF
--- a/usr/local/bin/tar
+++ b/usr/local/bin/tar
@@ -1,0 +1,5 @@
+#!/bin/sh
+## tar stores usernames and groups
+## mitigate showing user/group in metadata
+## set user and group to user/user
+exec /bin/tar --owner="user" --group="user" "$@"


### PR DESCRIPTION
tar stores your user and its group in the archive.
Make an archive with tar (or find one) then extract it like this:

`tar -zvtf archive-name.tar.gz | head -n 10`

The output will look like something like this:

```
-rw-r--r-- kevin/volunteer    290 2023-09-11 03:10 file1
-rw-r--r-- kevin/volunteer  23558 2024-07-30 11:45 file2
-rw-r--r-- bob/admin        10958 2024-07-30 12:54 file3
-rw-r--r-- frank/staff        110 2023-07-04 11:45 file4
```

`--owner="user" --group="user"` will mitigate this regardless of what the user logged in as is when creating a archive with tar.
## Mandatory Checklist

- [X] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
**Privacy by default when executing tar to make an archive**