### PR TITLE
Restore option to enable `slub_debug=FZ` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ configuration file.
 - Disable merging of slabs with similar size, which reduces the risk of
   triggering heap overflows and limits influencing slab cache layout.
 
+- Provides option to enable sanity checks and red zoning via slab debugging.
+  Not reccommened due to implicit disabling of kernel pointer hashing.
+
 - Enable memory zeroing at both allocation and free time, which mitigates some
   use-after-free vulnerabilities by erasing sensitive information in memory.
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ configuration file.
 - Disable merging of slabs with similar size, which reduces the risk of
   triggering heap overflows and limits influencing slab cache layout.
 
-- Provides option to enable sanity checks and red zoning via slab debugging.
-  Not reccommened due to implicit disabling of kernel pointer hashing.
+- Provide the option to enable sanity checks and red zoning via slab debugging.
+  Enabling this feature will implicitly disable kernel pointer hashing.
 
 - Enable memory zeroing at both allocation and free time, which mitigates some
   use-after-free vulnerabilities by erasing sensitive information in memory.

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -28,12 +28,17 @@ kver="$(dpkg-query --show --showformat='${Version}' "$kpkg")" 2>/dev/null || tru
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_nomerge"
 
-## Enable sanity checks and red zoning of slabs.
+## Enable sanity checks and red zoning of slabs via debugging options to detect corruption.
+## As a by product of debugging, this will implicitly disabling kernel pointer hashing.
+## Enabling will therefore leak exact and all kernel memory addresses to root.
+## Has the potential to cause a noticeable performance decrease.
 ##
 ## https://www.kernel.org/doc/html/latest/mm/slub.html
 ## https://lore.kernel.org/all/20210601182202.3011020-5-swboyd@chromium.org/T/#u
+## https://gitlab.tails.boum.org/tails/tails/-/issues/19613
 ##
-## Disabled as enabling this implicitly disables kernel pointer hashing.
+## The default kernel setting will be utilized until provided sufficient evidence to modify.
+## https://github.com/Kicksecure/security-misc/issues/253
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slub_debug=FZ"
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -40,7 +40,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_nomerge"
 ## The default kernel setting will be utilized until provided sufficient evidence to modify.
 ## https://github.com/Kicksecure/security-misc/issues/253
 ##
-#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slub_debug=FZ"
+#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_debug=FZ"
 
 ## Zero memory at allocation time and free time.
 ## Fills newly allocated pages, freed pages, and heap objects with zeros.

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -28,6 +28,15 @@ kver="$(dpkg-query --show --showformat='${Version}' "$kpkg")" 2>/dev/null || tru
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slab_nomerge"
 
+## Enable sanity checks and red zoning of slabs.
+##
+## https://www.kernel.org/doc/html/latest/mm/slub.html
+## https://lore.kernel.org/all/20210601182202.3011020-5-swboyd@chromium.org/T/#u
+##
+## Disabled as enabling this implicitly disables kernel pointer hashing.
+##
+#GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX slub_debug=FZ"
+
 ## Zero memory at allocation time and free time.
 ## Fills newly allocated pages, freed pages, and heap objects with zeros.
 ## Mitigates use-after-free exploits by erasing sensitive information in memory.


### PR DESCRIPTION
Addresses discussion in https://github.com/Kicksecure/security-misc/issues/253.

## Changes

There are no changes to the functionality of the code.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it