### PR TITLE
Enable `dev.tty.legacy_tiocsti=0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ space, user space, core dumps, and swap space.
 
 - Randomize the addresses (ASLR) for mmap base, stack, VDSO pages, and heap.
 
-- Provide the option to disable the use of legacy TIOCSTI operation which can be
-  used to inject keypresses.
+- Disable the use of legacy TIOCSTI operations which can be used to inject keypresses.
 
 - Disable asynchronous I/O as `io_uring` has been the source
   of numerous kernel exploits (when using Linux kernel version >= 6.6).

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -127,12 +127,14 @@ kernel.perf_event_paranoid=3
 ##
 kernel.randomize_va_space=2
 
-## Disable use of the legacy TIOCSTI operation which can be used to inject keypresses.
-## Will break screen readers as can no longer push characters into a controlling TTY.
-##
+## Disable the use of legacy TIOCSTI operations which can be used to inject keypresses.
+## Can lead to privilege escalation by pushing characters into a controlling TTY.
+## Will break out-dated screen readers that continue to rely on this legacy functionality.
 ## This is disabled by default when using Linux kernel >= 6.2.
 ##
-#dev.tty.legacy_tiocsti=0
+## https://lore.kernel.org/lkml/20221228205726.rfevry7ud6gmttg5@begin/T/
+##
+dev.tty.legacy_tiocsti=0
 
 ## Disable asynchronous I/O for all processes.
 ## Leading cause of numerous kernel exploits.


### PR DESCRIPTION
Apply KSPP recommendation:
https://kspp.github.io/Recommended_Settings#sysctls

## Changes

Enables `sysctl`:
`dev.tty.legacy_tiocsti=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it