### PR TITLE
Simplify syntax of some network-related `sysctl`'s

### DIFF
--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -275,8 +275,7 @@ net.ipv4.tcp_rfc1337=1
 ## https://forums.whonix.org/t/enable-reverse-path-filtering/8594
 ## https://seclists.org/oss-sec/2019/q4/122
 ##
-net.ipv4.conf.all.rp_filter=1
-net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.*.rp_filter=1
 
 ## Disable ICMP redirect acceptance and redirect sending messages.
 ## Prevents man-in-the-middle attacks and minimizes information disclosure.
@@ -289,14 +288,10 @@ net.ipv4.conf.default.rp_filter=1
 ## https://askubuntu.com/questions/118273/what-are-icmp-redirects-and-should-they-be-blocked
 ## https://github.com/Kicksecure/security-misc/pull/248
 ##
-net.ipv4.conf.all.accept_redirects=0
-net.ipv4.conf.default.accept_redirects=0
-net.ipv4.conf.all.send_redirects=0
-net.ipv4.conf.default.send_redirects=0
-net.ipv6.conf.all.accept_redirects=0
-net.ipv6.conf.default.accept_redirects=0
-#net.ipv4.conf.all.secure_redirects=1
-#net.ipv4.conf.default.secure_redirects=1
+net.ipv4.conf.*.accept_redirects=0
+net.ipv4.conf.*.send_redirects=0
+net.ipv6.conf.*.accept_redirects=0
+#net.ipv4.conf.*.secure_redirects=1
 
 ## Ignore ICMP echo requests.
 ## Prevents clock fingerprinting through ICMP timestamps and Smurf attacks.
@@ -316,15 +311,12 @@ net.ipv4.icmp_ignore_bogus_error_responses=1
 ##
 ## https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/sect-security_guide-server_security-disable-source-routing
 ##
-net.ipv4.conf.all.accept_source_route=0
-net.ipv4.conf.default.accept_source_route=0
-net.ipv6.conf.all.accept_source_route=0
-net.ipv6.conf.default.accept_source_route=0
+net.ipv4.conf.*.accept_source_route=0
+net.ipv6.conf.*.accept_source_route=0
 
 ## Do not accept IPv6 router advertisements and solicitations.
 ##
-net.ipv6.conf.all.accept_ra=0
-net.ipv6.conf.default.accept_ra=0
+net.ipv6.conf.*.accept_ra=0
 
 ## Disable SACK and DSACK.
 ## Select acknowledgements (SACKs) are a known common vector of exploitation.
@@ -362,8 +354,7 @@ net.ipv4.tcp_timestamps=0
 ##
 ## The logging of martian packets is currently disabled.
 ##
-#net.ipv4.conf.all.log_martians=1
-#net.ipv4.conf.default.log_martians=1
+#net.ipv4.conf.*.log_martians=1
 
 ## Enable IPv6 Privacy Extensions to prefer temporary addresses over public addresses.
 ## The temporary/privacy address is used as the source for all outgoing traffic.
@@ -379,5 +370,4 @@ net.ipv4.tcp_timestamps=0
 ##
 ## The use of IPv6 Privacy Extensions is currently disabled due to these breakages.
 ##
-#net.ipv6.conf.all.use_tempaddr=2
-#net.ipv6.conf.default.use_tempaddr=2
+#net.ipv6.conf.*.use_tempaddr=2

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -270,12 +270,15 @@ net.ipv4.tcp_rfc1337=1
 
 ## Enable reverse path filtering (source validation) of packets received from all interfaces.
 ## Prevents IP spoofing and mitigates vulnerabilities such as CVE-2019-14899.
+## The second "default" command fixes a bug in the existing kernel implementation.
 ##
 ## https://en.wikipedia.org/wiki/IP_address_spoofing
 ## https://forums.whonix.org/t/enable-reverse-path-filtering/8594
 ## https://seclists.org/oss-sec/2019/q4/122
+## https://github.com/Kicksecure/security-misc/pull/261
 ##
 net.ipv4.conf.*.rp_filter=1
+net.ipv4.conf.default.rp_filter=1
 
 ## Disable ICMP redirect acceptance and redirect sending messages.
 ## Prevents man-in-the-middle attacks and minimizes information disclosure.


### PR DESCRIPTION
This pull request simplifies the syntax of some network-related `sysctl`'s.

I do not think there is a need to distinguish between application to  'all' and 'default'. Ideally these setting should be applied across the board regardless of interface.

One could also make the case this might be a form of weak 'hardening' as we have simplified each setting to one line (defence-in-depth etc.).

Note this approach is also currently used by GrapheneOS's [infrastructure](https://github.com/GrapheneOS/infrastructure/blob/main/sysctl.d/local.conf).

For example:
```
net.ipv4.conf.all.accept_redirects=0
net.ipv4.conf.default.accept_redirects=0
```
to
```
net.ipv4.conf.*.accept_redirects=0
```

## Changes

There are (likely) no changes to the  functionality of the code.

EDIT: This PR attempts to fix a bug in the existing `rp_filter` implementation, see below. 

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it