### PR TITLE
Provide option to disable user namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ space, user space, core dumps, and swap space.
   can no longer be utilized. See [documentation](https://www.kicksecure.com/wiki/SysRq).
 
 - Restrict user namespaces to `CAP_SYS_ADMIN` as they can lead to substantial
-  privilege escalation.
+  privilege escalation. Optional - Disable all use of user namespaces.
 
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -93,11 +93,16 @@ kernel.sysrq=0
 ## User namespaces aim to improve sandboxing and accessibility for unprivileged users.
 ## Unprivileged user namespaces pose substantial privilege escalation risks.
 ## Restricting may lead to breakages in numerous software packages.
+## Uncomment the second sysctl to entirely disable user namespaces.
 ##
 ## https://madaidans-insecurities.github.io/linux.html#kernel
 ## https://github.com/a13xp0p0v/kernel-hardening-checker#questions-and-answers
 ##
+## KSPP=partial
+## KSPP sets the stricter sysctl user.max_user_namespaces=0.
+##
 kernel.unprivileged_userns_clone=0
+#user.max_user_namespaces=0
 
 ## Restricts kernel profiling to users with CAP_PERFMON.
 ## The performance events system should not be accessible by unprivileged users.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -94,9 +94,13 @@ kernel.sysrq=0
 ## Unprivileged user namespaces pose substantial privilege escalation risks.
 ## Restricting may lead to breakages in numerous software packages.
 ## Uncomment the second sysctl to entirely disable user namespaces.
+## Disabling entirely will reduce compatibility with some AppArmor profiles.
 ##
+## https://lwn.net/Articles/673597/
 ## https://madaidans-insecurities.github.io/linux.html#kernel
 ## https://github.com/a13xp0p0v/kernel-hardening-checker#questions-and-answers
+## https://github.com/NixOS/nixpkgs/pull/84522#issuecomment-614640601
+## https://github.com/Kicksecure/security-misc/pull/263
 ##
 ## KSPP=partial
 ## KSPP sets the stricter sysctl user.max_user_namespaces=0.


### PR DESCRIPTION
This pull request provides the option to disable user namespaces as per KSPP [recommendation](https://kspp.github.io/Recommended_Settings#sysctls).

## Changes

There are no changes to the functionality of the code.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
