### PR TITLE
Set `sysctl vm.mmap_min_addr=65536`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ space, user space, core dumps, and swap space.
 
 - Randomize the addresses (ASLR) for mmap base, stack, VDSO pages, and heap.
 
+- Raise the minimum address a process can request for memory mapping to 64KB to
+  protect against kernel null pointer dereference vulnerabilities.
+
 - Increase the maximum number of memory map areas a process is able to utilize.
 
 - Disallow registering interpreters for various (miscellaneous) binary formats based

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -207,6 +207,20 @@ fs.protected_regular=2
 ##
 kernel.randomize_va_space=2
 
+## Raise the minimum address a process can request for memory mapping to 64KB as a form of defense-in-depth.
+## Prevents kernel null pointer dereference vulnerabilities which may trigger kernel panics.
+## Protects against local unprivileged users gaining root privileges by mapping data to low memory pages.
+## Some legacy applications may still depend on low virtual memory addresses for proper functionality.
+##
+## https://googleprojectzero.blogspot.com/2023/01/exploiting-null-dereferences-in-linux.html
+## https://access.redhat.com/articles/20484
+## https://wiki.debian.org/mmap_min_addr
+##
+## KSPP=yes
+## KSPP sets CONFIG_DEFAULT_MMAP_MIN_ADDR=65536.
+##
+vm.mmap_min_addr=65536
+
 ## Increase the maximum number of memory map areas a process is permitted to utilize.
 ## Addresses performance, crash, and start-up issues for some memory-intensive applications.
 ## Required to accommodate the very large number of guard pages created by hardened_malloc.


### PR DESCRIPTION
This pull request sets `sysctl vm.mmap_min_addr=65536` as per the KSPP [recommendations](https://kspp.github.io/Recommended_Settings#x86_64) .

## Changes

Set `sysctl vm.mmap_min_addr=65536`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it