### PR TITLE
Enable `panic_on_warn=1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Kernel space:
 
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 
-- Force the kernel to panic on "oopses" that can potentially indicate and thwart
-  certain kernel exploitation attempts. Optional - Force immediate reboot on the
-  occurrence of a kernel panic and also set panic limit to one (when using Linux kernel >= 6.2).
+- Force the kernel to panic on both "oopses", which can potentially indicate and thwart
+  certain kernel exploitation attempts, and also kernel warnings in the `WARN()` path.
+  Optional - Force immediate reboot on the occurrence of a single kernel panic and also
+  (when using Linux kernel >= 6.2) limit the number of allowed panics to one.
 
 - Disable the use of legacy TIOCSTI operations which can be used to inject keypresses.
 

--- a/usr/libexec/security-misc/panic-on-oops
+++ b/usr/libexec/security-misc/panic-on-oops
@@ -12,12 +12,12 @@ if [ -f /usr/libexec/helper-scripts/pre.bsh ]; then
    source /usr/libexec/helper-scripts/pre.bsh
 fi
 
-## Makes the kernel panic on oopses. This prevents the kernel
-## from continuing to run a flawed processes. Many kernel exploits
-## will also cause an oops which this will make the kernel kill
-## the offending processes.
+## Makes the kernel panic on oopses and warnings. This prevents the
+## kernel from continuing to run a flawed processes. Many kernel
+## exploits will also cause an oops, these settings will make the
+## kernel kill the offending processes.
 #sysctl kernel.panic=-1
 sysctl kernel.panic_on_oops=1
-#sysctl kernel.panic_on_warn=1
+sysctl kernel.panic_on_warn=1
 #sysctl kernel.oops_limit=1
 #sysctl kernel.warn_limit=1


### PR DESCRIPTION
Partial follow-up on https://github.com/Kicksecure/security-misc/pull/264#issuecomment-2314954119.

This pull request sets `sysctl kernel.panic_on_warn=1` as per the KSPP [recommendations](https://kspp.github.io/Recommended_Settings#sysctls).

```
# Reboot after even 1 WARN or BUG/Oops. Adjust for your tolerances. (Since v6.2)
# If you want to set oops_limit greater than one, you will need to disable CONFIG_PANIC_ON_OOPS.
kernel.warn_limit = 1
kernel.oops_limit = 1
```

The proposed setting is not exactly equivalent as the KSPP assumes kernel  >= 6.2. Therefore, we are forced to use the older binary `kernel.panic_on_warn=1` enabling which does not allow setting numerical limits.

Could potentially still enable forcing reboot after a single kernel panic using `kernel.panic=-1` to be in full compliance with the KSPP. Thoughts?

## Changes

Set `sysctl kernel.panic_on_warn=1`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it