### PR TITLE
 Enable `ssbd=force-on`

### DIFF
--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -47,10 +47,12 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_v2=on"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_bhi=on"
 
 ## Disable Speculative Store Bypass (Spectre Variant 4).
+## Unconditionally enable mitigation for both kernel and userspace.
 ##
 ## https://www.suse.com/support/kb/doc/?id=000019189
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_store_bypass_disable=on"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ssbd=force-on"
 
 ## Enable mitigations for the L1TF vulnerability through disabling SMT
 ## and L1D flush runtime control.


### PR DESCRIPTION
As per the suggested review in https://github.com/Kicksecure/security-misc/issues/278, there is a minor addition we can make that in many cases is not neccessary.

Currently, our inclusion of `spec_store_bypass_disable=on` unconditionally disables Speculative Store Bypass .

The use of `ssbd=force-on` also unconditionally enables the mitigation for both kernel and userspace that is applicable in situations where a firmware based mitigation is offered.

Therefore, I see no harm in also including this parameter.

## Changes

Add  the `ssbd=force-on` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it