### PR TITLE
Enable umask hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Kernel space:
 
 - Force the kernel to panic on both "oopses", which can potentially indicate and thwart
   certain kernel exploitation attempts, and also kernel warnings in the `WARN()` path.
-  
+
 - Optional - Force immediate reboot on the occurrence of a single kernel panic and also
   (when using Linux kernel >= 6.2) limit the number of allowed panics to one.
 
@@ -573,9 +573,7 @@ See:
 #### umask
 
 Default `umask` is set to `027` for files created by non-root users such as
-user `user`. Broken. Disabled. See:
-
-* https://github.com/Kicksecure/security-misc/issues/184
+user `user`.
 
 This is done using the PAM module `pam_mkhomedir.so umask=027`.
 
@@ -589,7 +587,13 @@ https://wiki.debian.org/UserPrivateGroups
 
 Default `umask` is unchanged for root because then configuration files created
 in `/etc` by the system administrator would be unreadable by "others" and break
-applications. Examples include `/etc/firefox-esr` and `/etc/thunderbird`.
+applications. Examples include `/etc/firefox-esr` and `/etc/thunderbird`. The
+`umask` is also set to 022 via `sudoers` configuration, so that files created
+as root are world-readable even when using commands such as `sudo vi
+/etc/file` or `sudo -i; touch /etc/file`.
+
+`umask` is set to 022 rather than 027 when using `sudo`, so that commands such
+as `sudo vi /etc/configfile` and `sudo -i; touch /etc/file`
 
 See:
 

--- a/etc/sudoers.d/security-misc
+++ b/etc/sudoers.d/security-misc
@@ -3,3 +3,8 @@
 
 user ALL=NOPASSWD: /usr/libexec/security-misc/panic-on-oops
 %sudo ALL=NOPASSWD: /usr/libexec/security-misc/panic-on-oops
+
+## Use a more open umask when executing commands with sudo
+## Can be overridden on a per-user basis using .[z]profile if desirable
+Defaults umask_override
+Defaults umask=0022

--- a/usr/share/pam-configs/umask-security-misc
+++ b/usr/share/pam-configs/umask-security-misc
@@ -1,0 +1,8 @@
+Name: Restrict umask to 027 (by package security-misc)
+Default: yes
+Priority: 100
+Session-Type: Additional
+Session-Interactive-Only: yes
+Session:
+	[success=1 default=ignore]	pam_succeed_if.so uid eq 0
+	optional	pam_umask.so umask=027


### PR DESCRIPTION
This pull request enables umask hardening, preventing unauthorized access to user-created files.

## Changes

* Reinstates `[/usr/share/pam-configs/umask-security-misc](https://github.com/Kicksecure/security-misc/blob/master/usr/share/pam-configs/umask-security-misc)`, which sets a restrictive umask of 027 by default for all logins.
* Adds sudoers configuration to `/etc/sudoers.d/security-misc` that sets the umask to a less restrictive setting of 022.
* Updates README.md as appropriate.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #185 

## Notes

The following scenarios should be covered properly and have their umask set appropriately with this configuration:

* Console login
  * Goes through PAM, thus set to 027 for users and 022 for root
* Graphical login
  * Goes through PAM, thus set to 027 for users
* SSH login
  * Goes through PAM on Debian, thus set to 027 for users and 022 for root
* Graphical remote management
  * Tools that reuse a session (x11vnc, etc.)
    * Requires a pre-existing login, which goes through PAM, thus set to 027 for users
  * Tools that create a new session (xrdp)
    * Will depend on the tool, xrdp goes through PAM, thus set to 027 for users
* Privilege escalation
  * umask overridden to 022 via sudoers configuration, thus when escalating from `user` to `root` **or to any other user,** umask will become 022
    * Worthy of note, this will affect escalations to users like `debian-tor` as well. Additionally, when dropping privileges from root to a non-root user, the non-root shell will still have umask set to 022. This may or may not be considered intended behavior, but is probably safest for a default. Users who wish to change this can modify `~/.profile` and `~/.zprofile` to set umask to 027 or any other preferred value.

System services are considered out-of-scope, systemd manages the umask for those via the `UMask` setting in systemd units.