### PR TITLE
Reset file attributes if no configuration matches

### DIFF
--- a/usr/bin/permission-hardener
+++ b/usr/bin/permission-hardener
@@ -285,7 +285,7 @@ add_nosuid_statoverride_entry() {
     done
 
     local clean_output_prefix clean_output
-    clean_output_prefix="Managing (S|G)UID of line:"
+    clean_output_prefix="Managing S(G|U)ID of line:"
     clean_output="${setuid:+setuid='true'} ${setgid:+setgid='true'} existing_mode='${existing_mode}' new_mode='${new_mode}' file='${file_name}'"
     if test "${whitelists_disable_all:-}" = "true"; then
     log info "${clean_output_prefix} whitelists_disable_all=true ${clean_output}"
@@ -728,7 +728,11 @@ Examples:
 }
 
 case "${1:-}" in
-  enable) shift; apply "$@";;
+  enable)
+    shift
+    /usr/lib/security-misc/permission-hardener-extraneous
+    apply "$@"
+    ;;
   disable)
     shift
     case "${1:-}" in

--- a/usr/libexec/security-misc/permission-hardener-extraneous
+++ b/usr/libexec/security-misc/permission-hardener-extraneous
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eu
+
+get_and_save_file(){
+  file_save="${1}"
+  file_field="${2}"
+  shift 2
+  if test -z "${1}"; then
+    return 1
+  fi
+  grep -h -v -e "^$" -e "^\s*#" -- "${@}" |
+    cut -d " " "-f${file_field}" | sed 's|/$||' | sort -u |
+    tee -- "${file_save}" >/dev/null
+}
+
+store_dir="/var/lib/permission-hardener"
+unregistered_dir="${store_dir}/extraneous"
+unregistered_suid="${unregistered_dir}/unregistered-suid"
+existing_mode="${store_dir}/existing_mode/statoverride"
+#new_mode="${store_dir}/new_mode/statoverride"
+tmp_dir="/var/tmp/permission-hardener"
+conf_out="${tmp_dir}/suid-from-conf"
+stat_out="${tmp_dir}/suid-from-stat"
+rm -f -- "${conf_out}" "${stat_out}"
+if ! test -f "${existing_mode}"; then
+  exit
+fi
+if ! test -d "${tmp_dir}"; then
+  mkdir -p -- "${tmp_dir}"
+fi
+if ! test -d "${unregistered_dir}"; then
+  mkdir -p -- "${unregistered_dir}"
+fi
+
+# shellcheck disable=SC2046
+get_and_save_file "${conf_out}" 1 $(find /etc/permission-hardener.d/ /usr/local/etc/permission-hardener.d/ -maxdepth 1 -type f -name "*.conf" 2>/dev/null)
+get_and_save_file "${stat_out}" 4 "${existing_mode}"
+
+out="$(comm -13 --nocheck-order "${conf_out}" "${stat_out}")"
+
+if test -z "${out}"; then
+  exit
+fi
+
+if ! test -f "${unregistered_suid}"; then
+  while read -r file; do
+    mode="$(grep -e " ${file}$" -- "${existing_mode}" | cut -d " " -f3)"
+    case "${mode}" in
+      [24][0-7][0-7][0-7])
+        printf '%s\n' "${file}" | tee -a -- "${unregistered_suid}" >/dev/null
+        ;;
+    esac
+  done <<< "$out"
+fi
+
+for file in $(comm --nocheck-order -13 "${unregistered_suid}" - <<<"${out}"); do
+  if ! test -e "${file}"; then
+    continue
+  fi
+  permission-hardener disable "${file}"
+done


### PR DESCRIPTION
## Changes

Commenting or deleting a line/configuration file will make the next enabling of permission-hardener, either via shell or any package installation that triggers it, to reset the ownership and permissions of files that once were enabled but now don't have a configuration specifying them.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
