### PR TITLE
Refactor and add two CPU mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Kernel space:
 - Entirely disable the SysRq key so that the Secure Attention Key (SAK)
   can no longer be utilized. See [documentation](https://www.kicksecure.com/wiki/SysRq).
 
+- Optional - Disable all use of user namespaces.
+
 - Optional - Restrict user namespaces to `CAP_SYS_ADMIN` as they can lead to substantial
   privilege escalation.
-
-- Optional - Disable all use of user namespaces.
 
 - Restrict kernel profiling and the performance events system to `CAP_PERFMON`.
 

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -66,11 +66,13 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ssbd=force-on"
 
 ## L1 Terminal Fault (L1TF):
 ## Mitigate the vulnerability by disabling L1D flush runtime control and SMT.
+## If conditional L1D flushing, mitigate the vulnerability for certain KVM hypervisor configurations.
 ## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1tf=full,force"
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm-intel.vmentry_l1d_flush=always"
 
 ## Microarchitectural Data Sampling (MDS):
 ## Mitigate the vulnerability by clearing the buffer cache and disabling SMT.

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -134,6 +134,14 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mmio_stale_data=full,nosmt"
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX retbleed=auto,nosmt"
 
+## Cross-Thread Return Address Predictions:
+## Mitigate the vulnerability for certain KVM hypervisor configurations.
+## Currently affects AMD Zen 1-2 CPUs.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/cross-thread-rsb.html
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.mitigate_smt_rsb=1"
+
 ## Speculative Return Stack Overflow (SRSO):
 ## Mitigate the vulnerability by ensureing all RET instructions speculate to a controlled location.
 ## Currently affects AMD Zen 1-4 CPUs.

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -17,7 +17,7 @@
 ## https://www.intel.com/content/www/us/en/developer/topic-technology/software-security-guidance/advisory-guidance.html
 ## https://www.intel.com/content/www/us/en/developer/topic-technology/software-security-guidance/disclosure-documentation.html
 
-## Enable a subset of known mitigations for CPU vulnerabilities and disable SMT.
+## Enable a subset of known mitigations for some CPU vulnerabilities and disable SMT.
 ##
 ## KSPP=yes
 ## KSPP sets the kernel parameters.
@@ -27,7 +27,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mitigations=auto,nosmt"
 ## Disable SMT as it has been the cause of and amplified numerous CPU exploits.
 ## The only full mitigation of cross-HT attacks is to disable SMT.
 ## Disabling will significantly decrease system performance on multi-threaded tasks.
-## To enable SMT, remove this line and all other occurrences of "nosmt" in this file.
+## Note, this setting will prevent re-enabling SMT via the sysfs interface.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/core-scheduling.html
 ## https://forums.whonix.org/t/should-all-kernel-patches-for-cpu-bugs-be-unconditionally-enabled-vs-performance-vs-applicability/7647/17
@@ -36,95 +36,125 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mitigations=auto,nosmt"
 ## KSPP=yes
 ## KSPP sets the kernel parameter.
 ##
+## To re-enable SMT:
+## - Remove "nosmt=force".
+## - Remove all occurrences of ",nosmt" in this file (note the comma ",").
+## - Downgrade "l1tf=full,force" protection to "l1tf=flush".
+##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX nosmt=force"
 
-## Enable mitigations for both Spectre Variant 2 (indirect branch speculation)
-## and Intel branch history injection (BHI) vulnerabilities.
+## Spectre Side Channels (BTI and BHI):
+## Unconditionally enable mitigation for Spectre Variant 2 (branch target injection).
+## Enable mitigation for the Intel branch history injection vulnerability.
+## Currently affects both AMD and Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/spectre.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_v2=on"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spectre_bhi=on"
 
-## Disable Speculative Store Bypass (Spectre Variant 4).
-## Unconditionally enable mitigation for both kernel and userspace.
+## Speculative Store Bypass (SSB):
+## Mitigate Spectre Variant 4 by disabling speculative store bypass system-wide.
+## Unconditionally enable the mitigation for both kernel and userspace.
+## Currently affects both AMD and Intel CPUs.
 ##
+## https://en.wikipedia.org/wiki/Speculative_Store_Bypass
 ## https://www.suse.com/support/kb/doc/?id=000019189
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_store_bypass_disable=on"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ssbd=force-on"
 
-## Enable mitigations for the L1TF vulnerability through disabling SMT
-## and L1D flush runtime control.
+## L1 Terminal Fault (L1TF):
+## Mitigate the vulnerability by disabling L1D flush runtime control and SMT.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1tf=full,force"
 
-## Enable mitigations for the MDS vulnerability through clearing buffer cache
-## and disabling SMT.
+## Microarchitectural Data Sampling (MDS):
+## Mitigate the vulnerability by clearing the buffer cache and disabling SMT.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mds=full,nosmt"
 
-## Patches the TAA vulnerability by disabling TSX and enables mitigations using
-## TSX Async Abort along with disabling SMT.
+## TSX Asynchronous Abort (TAA):
+## Mitigate the vulnerability by disabling TSX.
+## If TSX is enabled, clear CPU buffer rings on transitions and disable SMT.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/tsx_async_abort.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx=off"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx_async_abort=full,nosmt"
 
-## Mark all huge pages in the EPT as non-executable to mitigate iTLB multihit.
+## iTLB Multihit:
+## Mitigate the vulnerability by marking all huge pages in the EPT as non-executable.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/multihit.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.nx_huge_pages=force"
 
-## Mitigations for SRBDS to prevent MDS attacks on RDRAND and RDSEED instructions
-## are only possible through microcode updates from Intel.
+## Special Register Buffer Data Sampling (SRBDS):
+## Mitigation of the vulnerability is only possible via microcode updates from Intel.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/special-register-buffer-data-sampling.html
 ## https://access.redhat.com/solutions/5142691
 
-## Enable the prctl() interface to prevent leaks from L1D on context switches.
+## L1D Flushing:
+## Mitigate leaks from the L1D cache on context switches by enabling the prctl() interface.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1d_flush.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1d_flush=on"
 
-## Mitigate numerous MMIO Stale Data vulnerabilities and disable SMT.
+## MMIO Stale Data:
+## Mitigate the vulnerability by appropriately clearing the CPU buffer and disabling SMT.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/processor_mmio_stale_data.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mmio_stale_data=full,nosmt"
 
-## Enable mitigations for RETBleed (Arbitrary Speculative Code Execution with
-## Return Instructions) vulnerability and disable SMT.
+## Arbitrary Speculative Code Execution with Return Instructions (Retbleed):
+## Mitigate the vulnerability through CPU-dependent implementation and disable SMT.
+## Currently affects both AMD Zen 1-2 and Intel CPUs.
 ##
+## https://en.wikipedia.org/wiki/Retbleed
+## https://comsec.ethz.ch/research/microarch/retbleed/
 ## https://www.suse.com/support/kb/doc/?id=000020693
+## https://access.redhat.com/solutions/retbleed
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX retbleed=auto,nosmt"
 
-## Control RAS overflow mitigation on AMD Zen CPUs.
+## Speculative Return Stack Overflow (SRSO):
+## Mitigate the vulnerability by ensureing all RET instructions speculate to a controlled location.
+## Currently affects AMD Zen 1-4 CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/srso.html
 ##
 ## The default kernel setting will be utilized until provided sufficient evidence to modify.
+## Using "spec_rstack_overflow=ipbp" may provide stronger security at a greater performance impact.
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX spec_rstack_overflow=safe-ret"
 
-## Enable Gather Data Sampling (GDS) mitigation.
-## Note for systems that have not received a suitable microcode update this will
-## entirely disable use of the AVX instructions set.
+## Gather Data Sampling (GDS):
+## Mitigate the vulnerability either via microcode update or by disabling AVX.
+## Note, without a suitable microcode update, this will entirely disable use of the AVX instructions set.
+## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/gather_data_sampling.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX gather_data_sampling=force"
 
-## Enable Register File Data Sampling (RFDS) mitigation on Intel Atom CPUs which
-## encompasses E-cores on hybrid architectures.
+## Register File Data Sampling (RFDS):
+## Mitigate the vulnerability by appropriately clearing the CPU buffer.
+## Currently affects Intel Atom CPUs (which encompasses E-cores on hybrid architectures).
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/reg-file-data-sampling.html
 ##

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -8,6 +8,7 @@
 ## If there is no explicit KSPP compliance notice, the setting is not mentioned by the KSPP.
 
 ## Enable known mitigations for CPU vulnerabilities.
+## Note, the mitigations for SSB and Retbleed are not currently mentioned in the first link.
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/index.html
 ## https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 ## https://forums.whonix.org/t/should-all-kernel-patches-for-cpu-bugs-be-unconditionally-enabled-vs-performance-vs-applicability/7647
@@ -40,6 +41,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX mitigations=auto,nosmt"
 ## - Remove "nosmt=force".
 ## - Remove all occurrences of ",nosmt" in this file (note the comma ",").
 ## - Downgrade "l1tf=full,force" protection to "l1tf=flush".
+## - Regenerate the dracut initramfs and then reboot system.
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX nosmt=force"
 
@@ -66,7 +68,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ssbd=force-on"
 
 ## L1 Terminal Fault (L1TF):
 ## Mitigate the vulnerability by disabling L1D flush runtime control and SMT.
-## If conditional L1D flushing, mitigate the vulnerability for certain KVM hypervisor configurations.
+## If L1D flushing is conditional, mitigate the vulnerability for certain KVM hypervisor configurations.
 ## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html
@@ -75,7 +77,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1tf=full,force"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm-intel.vmentry_l1d_flush=always"
 
 ## Microarchitectural Data Sampling (MDS):
-## Mitigate the vulnerability by clearing the buffer cache and disabling SMT.
+## Mitigate the vulnerability by clearing the CPU buffer cache and disabling SMT.
 ## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html
@@ -101,7 +103,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX tsx_async_abort=full,nosmt"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.nx_huge_pages=force"
 
 ## Special Register Buffer Data Sampling (SRBDS):
-## Mitigation of the vulnerability is only possible via microcode updates from Intel.
+## Mitigation of the vulnerability is only possible via microcode update from Intel.
 ## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/special-register-buffer-data-sampling.html
@@ -115,8 +117,8 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.nx_huge_pages=force"
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX l1d_flush=on"
 
-## MMIO Stale Data:
-## Mitigate the vulnerability by appropriately clearing the CPU buffer and disabling SMT.
+## Processor MMIO Stale Data:
+## Mitigate the vulnerabilities by appropriately clearing the CPU buffer and disabling SMT.
 ## Currently affects Intel CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/processor_mmio_stale_data.html
@@ -143,7 +145,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX retbleed=auto,nosmt"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX kvm.mitigate_smt_rsb=1"
 
 ## Speculative Return Stack Overflow (SRSO):
-## Mitigate the vulnerability by ensureing all RET instructions speculate to a controlled location.
+## Mitigate the vulnerability by ensuring all RET instructions speculate to a controlled location.
 ## Currently affects AMD Zen 1-4 CPUs.
 ##
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/srso.html

--- a/etc/default/grub.d/41_recovery_restrict.cfg
+++ b/etc/default/grub.d/41_recovery_restrict.cfg
@@ -7,10 +7,15 @@
 ## KSPP=no: not (currently) compliant with recommendations by the KSPP
 ## If there is no explicit KSPP compliance notice, the setting is not mentioned by the KSPP.
 
-## Disable access to single-user mode (i.e. recovery mode).
+## Disable access to single-user (recovery) mode.
+##
 ## https://forums.kicksecure.com/t/remove-linux-recovery-mode-boot-option-from-default-grub-boot-menu/727
-GRUB_DISABLE_RECOVERY='true'
+##
+GRUB_DISABLE_RECOVERY="true"
 
 ## Disable access to Dracut's recovery console.
+##
 ## https://forums.kicksecure.com/t/harden-dracut-initramfs-generator-by-disabling-recovery-console/724
-GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT rd.shell=0 rd.emergency=halt"
+##
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT rd.emergency=halt"
+GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT rd.shell=0"

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -117,41 +117,40 @@ vm.unprivileged_userfaultfd=0
 ##
 kernel.sysrq=0
 
-## Restrict user namespaces to users with CAP_SYS_ADMIN.
+## Disable user namespaces entirely.
 ## User namespaces aim to improve sandboxing and accessibility for unprivileged users.
-## Unprivileged user namespaces pose substantial privilege escalation risks.
-## Restricting may lead to breakages in numerous software packages.
-##
-## Flatpak requires unprivileged users to create new user namespaces for sandboxing.
-## https://github.com/flatpak/flatpak/wiki/User-namespace-requirements
-## https://salsa.debian.org/debian/bubblewrap/-/blob/debian/latest/debian/README.Debian
-## https://forums.kicksecure.com/t/can-not-run-flatpak-apps-after-kicksecure-update/592
-##
 ## Disabling entirely will reduce compatibility with some AppArmor profiles.
 ## Disabling entirely is known to break the UPower systemd service.
-##
-## Also breaks (some?) AppImages.
-## https://forums.kicksecure.com/t/cannot-run-some-appimage-apps-after-kicksecure-upate/594
-##
-## Might also break evolution (e-mail client):
-## https://forums.kicksecure.com/t/impossible-to-start-evolution-app-since-the-last-update/601
+## Not recommended due to well-known breakages across numerous software packages.
 ##
 ## https://lwn.net/Articles/673597/
 ## https://madaidans-insecurities.github.io/linux.html#kernel
-## https://gitlab.com/apparmor/apparmor/-/wikis/unprivileged_userns_restriction
 ## https://github.com/a13xp0p0v/kernel-hardening-checker#questions-and-answers
 ## https://github.com/NixOS/nixpkgs/pull/84522#issuecomment-614640601
-## https://github.com/flatpak/flatpak/wiki/User-namespace-requirements
 ## https://github.com/Kicksecure/security-misc/pull/263
-## https://github.com/Kicksecure/security-misc/issues/274
 ##
 ## KSPP=no
-## KSPP sets user.max_user_namespaces=0 sysctl, a Linux mainline, stricter setting.
+## KSPP sets the sysctl.
 ##
-## kernel.unprivileged_userns_clone is a Debian specific kernel feature. Not Linux mainline.
-#kernel.unprivileged_userns_clone=0
-## Uncomment the following sysctl to entirely disable user namespaces.
 #user.max_user_namespaces=0
+
+## Restrict user namespaces to users with CAP_SYS_ADMIN.
+## See the user.max_user_namespaces setting for more details.
+## This is a Debian-specific kernel feature, not a Linux mainline setting.
+## Unprivileged user namespaces pose substantial privilege escalation risks.
+## Flatpak requires unprivileged users to create new user namespaces for sandboxing.
+## Restricting is known to cause breakages in some AppImages and the Evolution Email Client.
+## Not recommended due to widespread breakages across many software packages.
+##
+## https://salsa.debian.org/debian/bubblewrap/-/blob/debian/latest/debian/README.Debian
+## https://gitlab.com/apparmor/apparmor/-/wikis/unprivileged_userns_restriction
+## https://github.com/flatpak/flatpak/wiki/User-namespace-requirements
+## https://forums.kicksecure.com/t/can-not-run-flatpak-apps-after-kicksecure-update/592
+## https://forums.kicksecure.com/t/cannot-run-some-appimage-apps-after-kicksecure-upate/594
+## https://forums.kicksecure.com/t/impossible-to-start-evolution-app-since-the-last-update/601
+## https://github.com/Kicksecure/security-misc/issues/274
+##
+#kernel.unprivileged_userns_clone=0
 
 ## Restricts kernel profiling to users with CAP_PERFMON.
 ## The performance events system should not be accessible by unprivileged users.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -281,7 +281,7 @@ fs.protected_fifos=2
 fs.protected_regular=2
 
 ## Enable ASLR for mmap base, stack, VDSO pages, and heap.
-## Forces shared libraries to be loaded to random addresses
+## Forces shared libraries to be loaded to random addresses.
 ## Start location of PIE-linked binaries is randomized.
 ## Heap randomization can lead to breakages with legacy applications.
 ##


### PR DESCRIPTION
Refactor two files to bring them inline with others in `/etc/default/grub.d/*`:
1. `/etc/default/grub.d/40_cpu_mitigations.cfg` 
2. `/etc/default/grub.d/41_recovery_restrict.cfg` 

Fix a missing full stop in `usr/lib/sysctl.d/990-security-misc.conf`.

Update presentation and discussion on the `sysctl`'s pertaining to user namespaces. I believe splitting the two settings into their own sections improves clarity.

Add two boot parameters related to VMs. Neither should be considered an active concern as by default we unconditionally disable both L1D flushing and SMT. Regardless, if a user decides to re-enable either, these mitigations might come in handy. 

## Changes
Enable two KVM related CPU mitigations via GRUB boot parameters:
`kvm-intel.vmentry_l1d_flush=always`
`kvm.mitigate_smt_rsb=1`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it