### PR TITLE
Deny sending and receiving shared media redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Networking:
 - Disable ICMP redirect acceptance and redirect sending messages to prevent
   man-in-the-middle attacks and minimize information disclosure.
 
-- Deny sending and receiving shared media redirects to reduce  the risk of IP
+- Deny sending and receiving shared media redirects to reduce the risk of IP
   spoofing attacks.
 
 - Optional - Enable ARP filtering to mitigate some ARP spoofing and ARP

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Networking:
 - Disable ICMP redirect acceptance and redirect sending messages to prevent
   man-in-the-middle attacks and minimize information disclosure.
 
-- Optional - Deny sending and receiving shared media redirects to reduce
-  the risk of IP spoofing attacks.
+- Deny sending and receiving shared media redirects to reduce  the risk of IP
+  spoofing attacks.
 
 - Optional - Enable ARP filtering to mitigate some ARP spoofing and ARP
   cache poisoning attacks.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -451,7 +451,7 @@ net.ipv6.conf.*.accept_redirects=0
 ## https://datatracker.ietf.org/doc/html/rfc1620
 ## https://www.frozentux.net/ipsysctl-tutorial/chunkyhtml/theconfvariables.html
 ##
-#net.ipv4.conf.*.shared_media=0
+net.ipv4.conf.*.shared_media=0
 
 ## Enable ARP (Address Resolution Protocol) filtering.
 ## Prevents the Linux kernel from handling the ARP table globally


### PR DESCRIPTION
As per https://github.com/Kicksecure/security-misc/pull/279#issuecomment-2496914818.

## Changes

Set `sysctl net.ipv4.conf.*.shared_media=0`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it