### PR TITLE
Enable ARP filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ Networking:
 - Optional - Deny sending and receiving shared media redirects to reduce
   the risk of IP spoofing attacks.
 
-- Optional - Enable ARP filtering to mitigate some ARP spoofing and ARP
-  cache poisoning attacks.
+- Enable ARP filtering to mitigate some ARP spoofing and ARP cache poisoning attacks.
 
 - Optional - Respond to ARP requests only if the target IP address is
   on-link, preventing some IP spoofing attacks.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -460,7 +460,7 @@ net.ipv6.conf.*.accept_redirects=0
 ##
 ## https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
 ##
-#net.ipv4.conf.*.arp_filter=1
+net.ipv4.conf.*.arp_filter=1
 
 ## Respond to ARP (Address Resolution Protocol) requests only if the target IP address is on-link.
 ## Reduces IP spoofing attacks by limiting the scope of allowable ARP responses.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -454,7 +454,7 @@ net.ipv6.conf.*.accept_redirects=0
 #net.ipv4.conf.*.shared_media=0
 
 ## Enable ARP (Address Resolution Protocol) filtering.
-## Prevents the Linux kernel from handling the ARP table globally
+## Prevents the Linux kernel from handling the ARP table globally.
 ## Can mitigate some ARP spoofing and ARP cache poisoning attacks.
 ## Improper filtering can lead to increased ARP traffic and inadvertently block legitimate ARP requests.
 ##


### PR DESCRIPTION
As per https://github.com/Kicksecure/security-misc/pull/279#issuecomment-2496914818.

## Changes

Set `sysctl net.ipv4.conf.*.arp_filter=1`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it