### PR TITLE
Respond to ARP requests only if the target IP address is on-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Networking:
 - Optional - Enable ARP filtering to mitigate some ARP spoofing and ARP
   cache poisoning attacks.
 
-- Optional - Respond to ARP requests only if the target IP address is
-  on-link, preventing some IP spoofing attacks.
+- Respond to ARP requests only if the target IP address is  on-link,
+  preventing some IP spoofing attacks.
 
 - Optional - Drop gratuitous ARP packets to prevent ARP cache poisoning
   via man-in-the-middle and denial-of-service attacks.

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -470,7 +470,7 @@ net.ipv6.conf.*.accept_redirects=0
 ## https://github.com/mullvad/mullvadvpn-app/pull/7141
 ## https://www.x41-dsec.de/static/reports/X41-Mullvad-Audit-Public-Report-2024-12-10.pdf
 ##
-#net.ipv4.conf.*.arp_ignore=2
+net.ipv4.conf.*.arp_ignore=2
 
 ## Drop gratuitous ARP (Address Resolution Protocol) packets.
 ## Stops ARP responses sent by a device without being explicitly requested.


### PR DESCRIPTION
As per https://github.com/Kicksecure/security-misc/pull/279#issuecomment-2496914818.

## Changes

Set `sysctl net.ipv4.conf.*.arp_ignore=2`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it