### PR TITLE
Drop gratuitous ARP packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Networking:
 - Optional - Respond to ARP requests only if the target IP address is
   on-link, preventing some IP spoofing attacks.
 
-- Optional - Drop gratuitous ARP packets to prevent ARP cache poisoning
-  via man-in-the-middle and denial-of-service attacks.
+- Drop gratuitous ARP packets to prevent ARP cache poisoning via
+  man-in-the-middle and denial-of-service attacks.
 
 - Ignore ICMP echo requests to prevent clock fingerprinting and Smurf attacks.
 

--- a/usr/lib/sysctl.d/990-security-misc.conf
+++ b/usr/lib/sysctl.d/990-security-misc.conf
@@ -482,7 +482,7 @@ net.ipv6.conf.*.accept_redirects=0
 ## https://patchwork.ozlabs.org/project/netdev/patch/1428652454-1224-3-git-send-email-johannes@sipsolutions.net/
 ## https://www.practicalnetworking.net/series/arp/gratuitous-arp/
 ##
-#net.ipv4.conf.*.drop_gratuitous_arp=1
+net.ipv4.conf.*.drop_gratuitous_arp=1
 
 ## Ignore ICMP echo requests.
 ## Prevents clock fingerprinting through ICMP timestamps and Smurf attacks.


### PR DESCRIPTION
As per https://github.com/Kicksecure/security-misc/pull/279#issuecomment-2496914818.

## Changes

Set `sysctl net.ipv4.conf.*.drop_gratuitous_arp=1`

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it