### PR TITLE
Add link to tabular comparison of CPU mitigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ Networking:
 
 Mitigations for known CPU vulnerabilities are enabled in their strictest form
 and simultaneous multithreading (SMT) is disabled. See the
-`/etc/default/grub.d/40_cpu_mitigations.cfg` configuration file.
+`/etc/default/grub.d/40_cpu_mitigations.cfg` configuration file. Note, to achieve
+complete protection for known CPU vulnerabilities, the latest security microcode
+(BIOS/UEFI) updates must also be installed on the system.
 
 Boot parameters relating to kernel hardening, DMA mitigations, and entropy
 generation are outlined in the `/etc/default/grub.d/40_kernel_hardening.cfg`

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -18,6 +18,9 @@
 ## https://www.intel.com/content/www/us/en/developer/topic-technology/software-security-guidance/advisory-guidance.html
 ## https://www.intel.com/content/www/us/en/developer/topic-technology/software-security-guidance/disclosure-documentation.html
 
+## Tabular comparison between the utility and functionality of various mitigations.
+## https://forums.whonix.org/t/kernel-hardening-security-misc/7296/587
+
 ## Enable a subset of known mitigations for some CPU vulnerabilities and disable SMT.
 ##
 ## KSPP=yes

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -21,6 +21,11 @@
 ## Tabular comparison between the utility and functionality of various mitigations.
 ## https://forums.whonix.org/t/kernel-hardening-security-misc/7296/587
 
+## For complete protection, users must install the latest relevant security microcode update.
+## BIOS/UEFI updates should only be obtained directly from OEMs and/or motherboard manufacturers.
+## Note that incorrectly performing system BIOS/UEFI updates can potentially lead to serious functionality issues.
+## The parameters below only provide (partial) protection at both the kernel and user space level.
+
 ## Enable a subset of known mitigations for some CPU vulnerabilities and disable SMT.
 ##
 ## KSPP=yes


### PR DESCRIPTION
Credit: FranklyFlawless on Whonix Forums for excellently reproducing the [table](https://lore.kernel.org/lkml/20240912190857.235849-1-david.kaplan@amd.com/T/#m81d5854d625e41baa18888a6183d0c7b56d05e36) located deep (around half way) in the kernel mailing list.

https://forums.whonix.org/t/kernel-hardening-security-misc/7296/587 

## Changes

No changes to the functionality of the codebase.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
