### PR TITLE
Disable PStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Kernel space:
 
 - Disable EFI persistent storage feature, preventing the kernel from writing crash logs and
   other persistent data to the EFI variable store.
-  
+
 Direct memory access:
 
 - Enable strict IOMMU translation to protect against some DMA attacks via the use
@@ -403,7 +403,7 @@ Miscellaneous modules:
 
 `/etc/kernel/postinst.d/30_remove-system-map`
 
-`/lib/systemd/system/remove-system-map.service`
+`/usr/lib/systemd/system/remove-system-map.service`
 
 `/usr/libexec/security-misc/remove-system.map`
 
@@ -412,21 +412,20 @@ Miscellaneous modules:
 
 `/etc/security/limits.d/30_security-misc.conf`
 
-`/etc/sysctl.d/30_security-misc.conf`
+`/usr/lib/sysctl.d/30_security-misc.conf`
 
-`/lib/systemd/coredump.conf.d/30_security-misc.conf`
+`/usr/lib/systemd/coredump.conf.d/30_security-misc.conf`
 
 - PStore is disabled as crash logs can contain sensitive system data such as
   kernel version, hostname, and users. See:
 
   `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf`
 
-- An initramfs hook sets the sysctl values in `/etc/sysctl.conf` and
-  `/etc/sysctl.d` before init is executed so sysctl hardening is enabled as
-  early as possible. This is implemented for `initramfs-tools` only because
-  this is not needed for `dracut` as `dracut` does that by default, at
-  least on `systemd` enabled systems. Not researched for non-`systemd` systems
-  by the author of this part of the readme.
+- An initramfs hook sets the sysctl values in `/usr/lib/sysctl.d/` before init
+  is executed so sysctl hardening is enabled as early as possible. This is
+  implemented for `initramfs-tools` only because this is not needed for `dracut`
+  as `dracut` does that by default, at least on `systemd` enabled systems. Not 
+  researched for non-`systemd` systems by the author of this part of the readme.
 
 ## Network hardening
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,11 @@ Miscellaneous modules:
 
 `/lib/systemd/coredump.conf.d/30_security-misc.conf`
 
+- PStore is disabled as crash logs can contain sensitive system data such as
+  kernel version, hostname, and users. See:
+
+  `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf`
+
 - An initramfs hook sets the sysctl values in `/etc/sysctl.conf` and
   `/etc/sysctl.d` before init is executed so sysctl hardening is enabled as
   early as possible. This is implemented for `initramfs-tools` only because

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ Kernel space:
 - Optional - Disable support for all x86 processes and syscalls (when using Linux kernel >= 6.7)
   to reduce attack surface.
 
+- Disable EFI persistent storage feature, preventing the kernel from writing crash logs and
+  other persistent data to the EFI variable store.
+  
 Direct memory access:
 
 - Enable strict IOMMU translation to protect against some DMA attacks via the use

--- a/README.md
+++ b/README.md
@@ -421,11 +421,12 @@ Miscellaneous modules:
 
   `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf`
 
-- An initramfs hook sets the sysctl values in `/usr/lib/sysctl.d/` before init
-  is executed so sysctl hardening is enabled as early as possible. This is
-  implemented for `initramfs-tools` only because this is not needed for `dracut`
-  as `dracut` does that by default, at least on `systemd` enabled systems. Not 
-  researched for non-`systemd` systems by the author of this part of the readme.
+- An initramfs hook sets the sysctl values in `/etc/sysctl.conf` and
+  `/etc/sysctl.d` before init is executed so sysctl hardening is enabled as
+  early as possible. This is implemented for `initramfs-tools` only because
+  this is not needed for `dracut` as `dracut` does that by default, at
+  least on `systemd` enabled systems. Not researched for non-`systemd` systems
+  by the author of this part of the readme.
 
 ## Network hardening
 

--- a/etc/default/grub.d/40_kernel_hardening.cfg
+++ b/etc/default/grub.d/40_kernel_hardening.cfg
@@ -223,6 +223,18 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vdso32=0"
 ##
 #GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ia32_emulation=0"
 
+## Disable EFI persistent storage feature.
+## Prevents the kernel from writing crash logs and other persistent data to the EFI variable store.
+##
+## https://blogs.oracle.com/linux/post/pstore-linux-kernel-persistent-storage-file-system
+## https://www.ais.com/understanding-pstore-linux-kernel-persistent-storage-file-system/
+## https://lwn.net/Articles/434821/
+## https://manpages.debian.org/testing/systemd/systemd-pstore.service.8.en.html
+## https://gitlab.tails.boum.org/tails/tails/-/issues/20813
+## https://github.com/Kicksecure/security-misc/issues/299
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX efi_pstore.pstore_disable=1"
+
 ## 2. Direct Memory Access:
 ##
 ## https://madaidans-insecurities.github.io/guides/linux-hardening.html#dma-attacks

--- a/usr/lib/systemd/pstore.conf.d/30_security-misc.conf
+++ b/usr/lib/systemd/pstore.conf.d/30_security-misc.conf
@@ -1,0 +1,5 @@
+## Copyright (C) 2025 - 2025 ENCRYPTED SUPPORT LLC <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+[PStore]
+Storage=none


### PR DESCRIPTION
This PR disables the PStore mechanism as first suggested in Issue https://github.com/Kicksecure/security-misc/issues/299 and PR https://github.com/Kicksecure/security-misc/pull/302.

## Changes

1. Disable pstore processing by systemd-pstore service via `/usr/lib/systemd/pstore.conf.d/30_security-misc.conf`.

2. Set the `efi_pstore.pstore_disable=1` kernel boot parameter via `/etc/default/grub.d/40_kernel_hardening.cfg`.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it