### PR TITLE
Prevent erroneous "Login blocked after [negative number] attempts" errors

### DIFF
--- a/usr/libexec/security-misc/pam-info
+++ b/usr/libexec/security-misc/pam-info
@@ -163,9 +163,9 @@ pam_faillock_output_count="$(echo "$pam_faillock_output" | wc -l)"
 ## example pam_faillock_output_count:
 ## 4
 
-## Do not count the first two informational textual output lines
-## (starting with "user:" and "When").
-failed_login_counter=$(( pam_faillock_output_count - 2 ))
+## Do not count the first two informational textual output lines (starting with "user:" and "When") if present,
+## but ensure failed_login_counter is not set to a negative value.
+failed_login_counter=$( [ $(( pam_faillock_output_count - 2 )) -gt 0 ] && echo $(( pam_faillock_output_count - 2 )) || echo "0" )
 
 ## example failed_login_counter:
 ## 2

--- a/usr/libexec/security-misc/pam-info
+++ b/usr/libexec/security-misc/pam-info
@@ -164,7 +164,7 @@ pam_faillock_output_count="$(echo "$pam_faillock_output" | wc -l)"
 ## 4
 
 ## Do not count the first two informational textual output lines (starting with "user:" and "When") if present,
-## but ensure failed_login_counter is not set to a negative value.
+## whilst ensuring failed_login_counter is not set to a negative value.
 failed_login_counter=$( [ $(( pam_faillock_output_count - 2 )) -gt 0 ] && echo $(( pam_faillock_output_count - 2 )) || echo "0" )
 
 ## example failed_login_counter:


### PR DESCRIPTION
For root, faillock appears to always* return an empty string (i.e. no table headers are present), yielding a zero-initialized pam_faillock_output_count and thus resulting in the calculation of a negative failed_login_counter value.

This can cause erroneous errors of the form "ERROR: Login blocked after [negative number] attempts" during sudo-ing and screen unlocking.

This commit modifies the initialization of failed_login_counter such that it cannot be negative and prevents the display of these incorrect warnings.

* Only rudimentary local tests were conducted

This pull request changes...

## Changes
failed_login_counter initialization in /usr/libexec/security-misc

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
Erroneous pam-info warnings during sudo-ing and screen unlocking.