### PR TITLE
remove  TemporaryTimeout=0 in Bluetooth config

### DIFF
--- a/etc/bluetooth/30_security-misc.conf
+++ b/etc/bluetooth/30_security-misc.conf
@@ -16,11 +16,6 @@ DiscoverableTimeout = 30
 # Default=0 (unlimited)
 MaxControllers=1
 
-# How long to keep temporary devices around
-# The value is in seconds. Default is 30.
-# 0 = disable timer, i.e. never keep temporary devices
-TemporaryTimeout = 0
-
 [Policy]
 # AutoEnable defines option to enable all controllers when they are found.
 # This includes adapters present on start as well as adapters that are plugged


### PR DESCRIPTION
The upstream documentation for `TemporaryTimeout = 0` was misleading and has been updated.
A TemporaryTimeout of 0 actually means that temporary devices stay around forever, rather than never being kept.

---

> Setting TemporaryTimeout to 0 never enables temporary_timer which means (...) the device will remain temporary forever (until the service is restarted).
- https://github.com/bluez/bluez/commit/313de9af36cbbd02d69ba12b8819e28f6a89bbd5

> ... setting TemporaryTimeout=0 will keep the temporary devices forever
- https://github.com/bluez/bluez/issues/1100#issuecomment-2854862195

## Changes
remove `TemporaryTimeout = 0` from /etc/bluetooth/30_security-misc.conf

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it
