### PR TITLE
Enable `vmscape=force`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ CPU mitigations:
 
 - Indirect Target Selection (ITS)
 
+- VMScape
+
 Boot parameters relating to kernel hardening, DMA mitigations, and entropy
 generation are outlined in the `/etc/default/grub.d/40_kernel_hardening.cfg`
 configuration file.

--- a/etc/default/grub.d/40_cpu_mitigations.cfg
+++ b/etc/default/grub.d/40_cpu_mitigations.cfg
@@ -195,3 +195,12 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX reg_file_data_sampling=on"
 ## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/indirect-target-selection.html
 ##
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX indirect_target_selection=force"
+
+## VMScape:
+## Mitigate the vulnerability by flushing branch predictors before returning to userspace when exiting guests.
+## Comprehensive protection may also require disabling SMT to limit cross-thread attacks.
+## Currently affects both AMD and Intel CPUs.
+##
+## https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/vmscape.html
+##
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX vmscape=force"


### PR DESCRIPTION
This pull request enables a new CPU mitigation to a stricter level.

https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/vmscape.html
https://comsec.ethz.ch/research/microarch/vmscape-exposing-and-exploiting-incomplete-branch-predictor-isolation-in-cloud-environments/
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=223ba8ee0a3986718c874b66ed24e7f87f6b8124

Note that the first link at time of submitting this PR is inactive as the kernel docs should be updated soon. The link is the correct one as it exactly matches that presented in the third link providing the commit details.

## Changes

Adds the `vmscape=force` kernel boot parameter.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it