### PR TITLE
fix(pam): pass profile names to pam-auth-update --remove

### DIFF
--- a/debian/security-misc-shared.postrm
+++ b/debian/security-misc-shared.postrm
@@ -16,7 +16,11 @@ true "
 "
 
 ## https://forums.whonix.org/t/is-security-misc-suitable-for-hardening-bridges-and-relays/8299/11
-pam-auth-update --package --remove "$DPKG_MAINTSCRIPT_PACKAGE"
+## Debian Policy 7.2: there is no guarantee that dependencies (here
+## libpam-runtime) are available when postrm runs; skip gracefully then.
+if command -v pam-auth-update >/dev/null 2>&1; then
+   pam-auth-update --package
+fi
 
 rm -f /etc/sysctl.d/30_security-misc_aslr-mmap.conf
 

--- a/debian/security-misc-shared.prerm
+++ b/debian/security-misc-shared.prerm
@@ -16,7 +16,20 @@ true "
 "
 
 if [ "$1" = remove ]; then
-   pam-auth-update --package --remove "$DPKG_MAINTSCRIPT_PACKAGE"
+   ## 'pam-auth-update --remove' matches pam-config FILENAMES under
+   ## /usr/share/pam-configs/, not the package name. Disable while the helper
+   ## scripts under /usr/libexec/security-misc/ still exist. Keep in sync with
+   ## security-misc-shared.install and usr/share/pam-configs/.
+   ## See pam-auth-update(8).
+   pam-auth-update --package --remove \
+      block-unsafe-logins-security-misc \
+      console-lockdown-security-misc \
+      faillock-preauth-security-misc \
+      mkhomedir-security-misc \
+      pam-abort-on-locked-password-security-misc \
+      umask-security-misc \
+      unix-faillock-security-misc \
+      wheel-security-misc
 fi
 
 true "INFO: debhelper beginning here."


### PR DESCRIPTION
## Summary

The `prerm`/`postrm` scripts try to disable this package's PAM profiles on
removal, but they pass the package name to `pam-auth-update --remove`, which
matches profile *filenames* — so the early-disable was silently a no-op. On
every removal, `/etc/pam.d/common-*` kept referencing helper scripts dpkg had
already deleted; `block-unsafe-logins` is a Priority 1100 `requisite`, so all
authentication failed until postrm's reconciliation ran — permanently if the
postrm failed first (ArrayBolt3's reproduction above).

## Changes

- **Root cause:** `pam-auth-update --remove` matches config **filenames**
  (readdir of `/usr/share/pam-configs/` — see `debian/local/pam-auth-update`
  in the [pam source](https://sources.debian.org/src/pam/latest/debian/local/pam-auth-update/)).
  An unknown target such as `security-misc-shared` is accepted without
  validation and simply never matches.
- **`prerm`** (on `remove` only): pass the 8 actual profile filenames,
  unguarded. This is the man-page-documented purpose of `--remove` ("before
  the modules they reference are removed from disk") and the ecosystem norm:
  libpam-mount, sssd, and fprintd all use this exact shape (unguarded,
  `$1 = remove` only), and debputy auto-generates it. If pam-auth-update were
  somehow unrunnable, the removal aborts — failing closed instead of
  recreating the dangling-requisite lockout.
- **`postrm`**: replace the inert `--remove <pkg>` with a plain
  `pam-auth-update --package` reconciliation in **all** postrm states,
  guarded by `command -v` (Policy §7.2: no dependency guarantee at postrm
  time). With profile files still on disk (`upgrade`/`abort-*`)
  reconciliation is a no-op, so nothing is stripped mid-transaction — this
  addresses the review question about `failed-upgrade`/`abort-install`/
  `abort-upgrade`.

## Testing

Everything below ran in `debian:stable-slim` against a .deb built from this
revision (the real profiles, the referenced helper scripts, these exact
maintainer scripts) and can be re-run from the descriptions alone.

- Root cause is directly observable: `pam-auth-update --package --remove
  security-misc-shared` changes nothing, while `--remove` with the actual
  profile filenames removes the entries. With this PR, `prerm remove` strips
  all 8 profiles from `common-*` (including an `--enable`d console-lockdown)
  while the helper scripts and profile files are still on disk, and
  `dpkg -i` → `dpkg -r` → `dpkg -P` exit 0 with no reference to
  `/usr/libexec/security-misc` left anywhere in `/etc/pam.d` at any point.
- Failure injection with ArrayBolt3's pre.bsh trick (fail only the postrm):
  with the current code, removal fails and `common-auth` is left pointing at
  the deleted `block-unsafe-logins` helper — the reported lockout state; with
  this PR, removal still fails but `/etc/pam.d` is already clean. Forcing
  prerm to fail *after* its `--remove` instead makes dpkg run
  `postinst abort-remove`, the package stays installed, and the outcome is
  exactly the behavior change disclosed under Notes below.
- Every postrm invocation dpkg can make (`upgrade`, `failed-upgrade`, both
  `abort-install` argument forms, `abort-upgrade`, `disappear`, `purge`)
  exits 0 and leaves `common-*` untouched while the profile files are
  present. `postrm purge` also exits 0 with pam-auth-update removed from
  PATH, and `prerm remove` without pam-auth-update fails closed as intended.
  `bash -n` passes on both scripts; shellcheck reports nothing on the
  changed lines.

## Notes for reviewers

- **Behavior change vs the old inert code** (also disclosed in the commit
  message): an effective `--remove` drops the 8 names from
  `/var/lib/pam/seen`. If a removal is aborted after prerm ran (dpkg then
  calls `postinst abort-remove`, whose reconciliation runs), the seven
  `Default: yes` profiles are re-enabled — including any an administrator had
  deliberately disabled — and `console-lockdown-security-misc`
  (`Default: no`) stays off until re-enabled; reinstalling does not restore
  it, since preinst's `--enable` is behind a `do_once` stamp. On all
  *completed* paths (remove, purge, upgrade, remove→reinstall) the end state
  is identical to before this change. The same side-effect class exists in
  sssd and libcap2.
- **Caveat:** the 8-name list in `prerm` must stay in sync with
  `debian/security-misc-shared.install` and `usr/share/pam-configs/`; a
  forgotten name is still swept by the postrm reconciliation within the same
  dpkg run.
- **Pre-existing limitation (unchanged):** with local modifications inside
  the pam-auth-update managed block of `common-*`, pam-auth-update declines
  to act and exits 0, so neither the old nor the new calls change anything on
  such systems.
